### PR TITLE
Improving starting utask on dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ COPY .  /go/src/github.com/ovh/utask
 WORKDIR /go/src/github.com/ovh/utask
 RUN make re && \
     mv hack/Makefile-child Makefile && \
-    mkdir -p /app/plugins /app/templates /app/config /app/init /app/static/dashboard /app/static/editor
+    mkdir -p /app/plugins /app/templates /app/config /app/init /app/static/dashboard /app/static/editor && \
+    mv hack/wait-for-it/wait-for-it.sh /wait-for-it.sh && \
+    chmod +x /wait-for-it.sh
 WORKDIR /app
 
 COPY --from=js-builder /home/node/ui/dashboard/dist/utask-ui/*  /app/static/dashboard/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:latest AS js-builder
 
-RUN npm install -g @angular/cli 
+RUN npm install -g @angular/cli
 COPY ./ui /home/node/ui
 
 # dashboard
@@ -11,21 +11,20 @@ RUN BASEHREF=/ui/dashboard/ PREFIX_API_BASE_URL=/ make build-prod
 WORKDIR /home/node/ui/editor
 RUN BASEHREF=/ui/editor/ make build-prod
 
-FROM golang:1.12.7 
+FROM golang:1.12
 
 COPY .  /go/src/github.com/ovh/utask
 WORKDIR /go/src/github.com/ovh/utask
-RUN make re
-RUN mv hack/Makefile-child Makefile
-
-RUN mkdir -p /app/plugins /app/templates /app/config /app/init /app/static/dashboard /app/static/editor
+RUN make re && \
+    mv hack/Makefile-child Makefile && \
+    mkdir -p /app/plugins /app/templates /app/config /app/init /app/static/dashboard /app/static/editor
 WORKDIR /app
 
 COPY --from=js-builder /home/node/ui/dashboard/dist/utask-ui/*  /app/static/dashboard/
 COPY --from=js-builder /home/node/ui/editor/dist/utask-editor/* /app/static/editor/
 
-RUN cp /go/src/github.com/ovh/utask/utask /app/utask
-RUN chmod +x /app/utask
+RUN cp /go/src/github.com/ovh/utask/utask /app/utask && \
+    chmod +x /app/utask
 
 EXPOSE 8081
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3"
 services:
   utask:
     build: .
+    command: ["/wait-for-it.sh", "db:5432", "--", "/app/utask"]
     environment:
       DEBUG:              'true'
       DEV:                'true'
@@ -14,6 +15,8 @@ services:
       - 8081:8081
     volumes:
       - "./templates:/app/templates:ro"
+    depends_on:
+      - db
   db:
     image: postgres:9.5.3
     environment:

--- a/hack/wait-for-it/LICENSE
+++ b/hack/wait-for-it/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2016 Giles Hall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hack/wait-for-it/wait-for-it.sh
+++ b/hack/wait-for-it/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
This pull-request introduces script wait-for-it.sh to avoid utask binary starts before database is ready.

Previous behavior: 

```
romain@laptop:~/utask‼> docker-compose up
Creating network "utask_default" with the default driver
Creating utask_db_1 ... done
Creating utask_utask_1 ... done
Attaching to utask_db_1, utask_utask_1
utask_1  | time="2019-11-16T16:38:04Z" level=info msg="[DatabaseConfig] Using 50 max open connections, 30 max idle connections, 60 seconds timeout"
utask_1  | time="2019-11-16T16:38:04Z" level=fatal msg="dial tcp 172.22.0.2:5432: connect: connection refused"
db_1     | The files belonging to this database system will be owned by user "postgres".
db_1     | This user must also own the server process.
db_1     | 
db_1     | The database cluster will be initialized with locale "en_US.utf8".
db_1     | The default database encoding has accordingly been set to "UTF8".
db_1     | The default text search configuration will be set to "english".
db_1     | 
db_1     | Data page checksums are disabled.
db_1     | 
db_1     | fixing permissions on existing directory /var/lib/postgresql/data ... ok
db_1     | creating subdirectories ... ok
db_1     | selecting default max_connections ... 100
db_1     | selecting default shared_buffers ... 128MB
db_1     | selecting dynamic shared memory implementation ... posix
db_1     | creating configuration files ... ok
db_1     | creating template1 database in /var/lib/postgresql/data/base/1 ... ok
db_1     | initializing pg_authid ... ok
db_1     | initializing dependencies ... ok
db_1     | creating system views ... ok
db_1     | loading system objects' descriptions ... ok
db_1     | creating collations ... ok
db_1     | creating conversions ... ok
db_1     | creating dictionaries ... ok
db_1     | setting privileges on built-in objects ... ok
db_1     | creating information schema ... ok
db_1     | loading PL/pgSQL server-side language ... ok
utask_utask_1 exited with code 1
```

New behavior:
```
romain@maestro:~/utask$ docker-compose up
Creating network "utask_default" with the default driver
Creating utask_db_1 ... done
Creating utask_utask_1 ... done
Attaching to utask_db_1, utask_utask_1
db_1     | The files belonging to this database system will be owned by user "postgres".
....
utask_1  | wait-for-it.sh: waiting 15 seconds for db:5432
db_1     | creating subdirectories ... ok
...
db_1     | LOG:  incomplete startup packet
utask_1  | wait-for-it.sh: db:5432 is available after 3 seconds
utask_1  | time="2019-11-16T16:46:19Z" level=info msg="[DatabaseConfig] Using 50 max open connections, 30 max idle connections, 60 seconds timeout"
utask_1  | time="2019-11-16T16:46:19Z" level=info msg="Created task template 'hello-world-now'"
utask_1  | [GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.
```

Also switch base image from golang:1.12.7 to golang:1.12 (pointing on latest build from 1.12, currently 1.12.13) to embed last Golang security fixes.

Also saving 2 docker layers :)