### PR TITLE
expose version on API, fix travis release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,6 @@ script:
   - make
   - make release
 
-deploy:
-  provider: releases
-  api_key: $GITHUB_TOKEN
-  file: 
-    - install-utask.sh
-    - utask
-  skip_cleanup: true
-  draft: true
-  on:
-    tags: true
-
 after_success:
   - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
   - curl -sL https://git.io/goreleaser | head -n -2 | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ before_script:
 
 script:
   - make test-travis
-  - make
-  - make release
+  - make release # still don't know where to upload install-utask.sh ...
 
 after_success:
   - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,21 @@ before_script:
 
 script:
   - make test-travis
+  - make
+  - make release
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file: install-utask.sh
+  skip_cleanup: true
+  draft: true
+  on:
+    tags: true
 
 after_success:
   - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
   - curl -sL https://git.io/goreleaser | head -n -2 | bash
   - tar -xf /tmp/goreleaser.tar.gz -C $GOPATH/bin
+  - git reset --hard HEAD  # reset go.mod and go.sum, modified by make test-travis, is this an OK move?
   - make run-goreleaser

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ script:
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN
-  file: install-utask.sh
+  file: 
+    - install-utask.sh
+    - utask
   skip_cleanup: true
   draft: true
   on:

--- a/api/server.go
+++ b/api/server.go
@@ -241,11 +241,20 @@ func (s *Server) build(ctx context.Context) {
 				},
 				maintenanceMode,
 				tonic.Handler(handler.CancelResolution, 204))
+
 			//	authRoutes.POST("/resolution/:id/rollback",
 			//		[]fizz.OperationOption{
 			// 			fizz.Summary(""),
 			//		},
 			//		tonic.Handler(handler.ResolutionRollback, 200))
+
+			authRoutes.GET("/",
+				[]fizz.OperationOption{
+					fizz.Summary("Redirect to /meta"),
+				},
+				func(c *gin.Context) {
+					c.Redirect(http.StatusMovedPermanently, "/meta")
+				})
 
 			authRoutes.GET("/meta",
 				[]fizz.OperationOption{
@@ -306,6 +315,8 @@ type rootOut struct {
 	ApplicationName string `json:"application_name"`
 	UserIsAdmin     bool   `json:"user_is_admin"`
 	Username        string `json:"username"`
+	Version         string `json:"version"`
+	Commit          string `json:"commit"`
 }
 
 func rootHandler(c *gin.Context) (*rootOut, error) {
@@ -313,6 +324,8 @@ func rootHandler(c *gin.Context) (*rootOut, error) {
 		ApplicationName: utask.AppName(),
 		UserIsAdmin:     auth.IsAdmin(c) == nil,
 		Username:        auth.GetIdentity(c),
+		Version:         utask.Version,
+		Commit:          utask.Commit,
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Pablo Pérez Schröder <2639770+nomonamo@users.noreply.github.com>

should fix #30 

- travis + goreleaser is unable to create a draft release upon finding modified files (go.mod + go.sum)

- attempting to upload generated install script on tagged release

- expose version and commit hash on API