### PR TITLE
feat: Split payload and metadata from SSH plugin

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -61,31 +61,7 @@ The `Metadata` to fetch informations about plugin execution:
 
 ```json
 {
-  "output": "Connecting...
-    Pseudo-terminal will not be allocated because stdin is not a terminal.
-    Welcome to Ubuntu 19.04 (GNU/Linux 5.0.0-31-generic x86_64)
-
-     * Documentation:  https://help.ubuntu.com
-     * Management:     https://landscape.canonical.com
-     * Support:        https://ubuntu.com/advantage
-
-      System information as of Mon Dec  9 11:03:03 UTC 2019
-
-      System load:  0.0               Processes:           111
-      Usage of /:   23.7% of 9.52GB   Users logged in:     0
-      Memory usage: 18%               IP address for ens3: 10.00.00.01
-      Swap usage:   0%
-
-     * Overheard at KubeCon: \"microk8s.status just blew my mind\".
-
-         https://microk8s.io/docs/commands#microk8s.status
-
-    26 updates can be installed immediately.
-    0 of these updates are security updates.
-
-
-    *** System restart required ***
-    {\"pid\":\"3931\",\"service_name\":\"nginx\",\"service_uptime\":\"1715606\"}",
+  "output": "Connecting...\nWelcome to Ubuntu 19.04 (GNU/Linux ... x86_64)\n[...]\n{\"pid\":\"3931\",\"service_name\":\"nginx\",\"service_uptime\":\"1715606\"}",
   "exit_status": "0",
   "exit_signal": "0",
   "exit_msg": "exited 0"

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -62,8 +62,8 @@ The `Metadata` to fetch informations about plugin execution:
 ```json
 {
   "output": "{\"foo\":\"bar\"}}",
-	"exit_status": "0",
-	"exit_signal": "0",
-	"exit_msg": "exited 0"
+  "exit_status": "0",
+  "exit_signal": "0",
+  "exit_msg": "exited 0"
 }
 ```

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -42,15 +42,28 @@ action:
     ssh_key: '{{.config.mySSHKey}}'
 ```
 
-The output resulting from this configuration will be:
+## Requirements
 
-```js
+None by default. Ssh credentials should be retrieved from `{{.config.[sshkey]}}` rather than hardcoded on the template.
+
+## Note
+
+The plugin returns two objects, the `Payload` of the execution:
+
+```json
 {
   "pid": "1234",
   "uptime": "876123"
 }
 ```
 
-## Requirements
+The `Metadata` to fetch informations about plugin execution:
 
-None by default. Ssh credentials should be retrieved from `{{.config.[sshkey]}}` rather than hardcoded on the template.
+```json
+{
+  "output": "{\"foo\":\"bar\"}}",
+	"exit_status": "0",
+	"exit_signal": "0",
+	"exit_msg": "exited 0"
+}
+```

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -48,12 +48,12 @@ None by default. Ssh credentials should be retrieved from `{{.config.[sshkey]}}`
 
 ## Note
 
-The plugin returns two objects, the `Payload` of the execution:
+The plugin returns two objects, the `Payload` of the execution as defined in the result field of configuration:
 
 ```json
 {
-  "pid": "1234",
-  "uptime": "876123"
+  "pid": "3931",
+  "uptime": "1715606"
 }
 ```
 
@@ -61,7 +61,31 @@ The `Metadata` to fetch informations about plugin execution:
 
 ```json
 {
-  "output": "{\"foo\":\"bar\"}}",
+  "output": "Connecting...
+    Pseudo-terminal will not be allocated because stdin is not a terminal.
+    Welcome to Ubuntu 19.04 (GNU/Linux 5.0.0-31-generic x86_64)
+
+     * Documentation:  https://help.ubuntu.com
+     * Management:     https://landscape.canonical.com
+     * Support:        https://ubuntu.com/advantage
+
+      System information as of Mon Dec  9 11:03:03 UTC 2019
+
+      System load:  0.0               Processes:           111
+      Usage of /:   23.7% of 9.52GB   Users logged in:     0
+      Memory usage: 18%               IP address for ens3: 10.00.00.01
+      Swap usage:   0%
+
+     * Overheard at KubeCon: \"microk8s.status just blew my mind\".
+
+         https://microk8s.io/docs/commands#microk8s.status
+
+    26 updates can be installed immediately.
+    0 of these updates are security updates.
+
+
+    *** System restart required ***
+    {\"pid":"3931\",\"service_name\":\"nginx\",\"service_uptime\":\"1715606\"}",
   "exit_status": "0",
   "exit_signal": "0",
   "exit_msg": "exited 0"

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -44,7 +44,7 @@ action:
 
 ## Requirements
 
-None by default. Ssh credentials should be retrieved from `{{.config.[sshkey]}}` rather than hardcoded on the template.
+None by default. Ssh credentials should be retrieved from `{{.config.mySSHKey}}` rather than hardcoded on the template.
 
 ## Note
 

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -85,7 +85,7 @@ The `Metadata` to fetch informations about plugin execution:
 
 
     *** System restart required ***
-    {\"pid":"3931\",\"service_name\":\"nginx\",\"service_uptime\":\"1715606\"}",
+    {\"pid\":\"3931\",\"service_name\":\"nginx\",\"service_uptime\":\"1715606\"}",
   "exit_status": "0",
   "exit_signal": "0",
   "exit_msg": "exited 0"

--- a/pkg/plugins/builtin/ssh/ssh.go
+++ b/pkg/plugins/builtin/ssh/ssh.go
@@ -22,7 +22,7 @@ const (
 
 // ssh plugin opens an ssh connection and runs commands on target machine
 var (
-	Plugin = taskplugin.New("ssh", "0.1", execssh,
+	Plugin = taskplugin.New("ssh", "0.2", execssh,
 		taskplugin.WithConfig(configssh, ConfigSSH{}),
 	)
 )

--- a/pkg/plugins/builtin/ssh/ssh.go
+++ b/pkg/plugins/builtin/ssh/ssh.go
@@ -184,8 +184,6 @@ trap printResultJSON EXIT
 		"exit_msg":    exitMessage,
 	}
 
-	payload := make(map[string]interface{})
-
 	lastNL := strings.LastIndexByte(outStr, '{')
 	if lastNL == -1 {
 		return nil, metadata, nil
@@ -193,15 +191,11 @@ trap printResultJSON EXIT
 
 	// Unmarshal printResultJSON's output
 	lastLine := outStr[lastNL:]
-	m := map[string]string{}
+	payload := make(map[string]interface{})
 
-	err = json.Unmarshal([]byte(lastLine), &m)
+	err = json.Unmarshal([]byte(lastLine), &payload)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	for k, v := range m {
-		payload[k] = v
+		return nil, metadata, err
 	}
 
 	if exitStatus != 0 && !cfg.AllowExitNonZero {

--- a/pkg/plugins/builtin/ssh/ssh.go
+++ b/pkg/plugins/builtin/ssh/ssh.go
@@ -184,18 +184,16 @@ trap printResultJSON EXIT
 		"exit_msg":    exitMessage,
 	}
 
-	lastNL := strings.LastIndexByte(outStr, '{')
-	if lastNL == -1 {
-		return nil, metadata, nil
-	}
-
-	// Unmarshal printResultJSON's output
-	lastLine := outStr[lastNL:]
 	payload := make(map[string]interface{})
 
-	err = json.Unmarshal([]byte(lastLine), &payload)
-	if err != nil {
-		return nil, metadata, err
+	lastNL := strings.LastIndexByte(outStr, '{')
+	if lastNL != -1 {
+		lastLine := outStr[lastNL:]
+
+		err = json.Unmarshal([]byte(lastLine), &payload)
+		if err != nil {
+			return nil, metadata, err
+		}
 	}
 
 	if exitStatus != 0 && !cfg.AllowExitNonZero {


### PR DESCRIPTION
As discussed /w @loopfz, it's better to split JSON payload object and execution metadata.

Signed-off-by: Valentin Pichard <7628998+w3st3ry@users.noreply.github.com>
