### PR TITLE
Plugin subtask: fix templating instructions (escape hyphens)

### DIFF
--- a/engine/templates_tests/foreach.yaml
+++ b/engine/templates_tests/foreach.yaml
@@ -43,7 +43,7 @@ steps:
         conditions:
             - type: check
               if:
-                - value: '{{.step.this.output.concat}}'
+                - value: '{{ index .step "this" "output" "concat"}}'
                   operator: EQ
                   expected: foo-c-bar-c
               then:

--- a/pkg/plugins/builtin/subtask/subtask.go
+++ b/pkg/plugins/builtin/subtask/subtask.go
@@ -40,7 +40,7 @@ type SubtaskContext struct {
 
 func ctx(stepName string) interface{} {
 	return &SubtaskContext{
-		TaskID:            fmt.Sprintf("{{if .step.%s.output}}{{.step.%s.output.id}}{{end}}", stepName, stepName),
+		TaskID:            fmt.Sprintf(`{{ if (index .step "%s" "output") }}{{ index .step "%s" "output" "id" }}{{ end }}`, stepName, stepName),
 		RequesterUsername: "{{.task.requester_username}}",
 	}
 }


### PR DESCRIPTION
Fixes #54 