### PR TITLE
feat: Personalize path prefix for dashboard/editor and API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ COPY ./ui /home/node/ui
 
 # dashboard
 WORKDIR /home/node/ui/dashboard
-RUN BASEHREF=/ui/dashboard/ PREFIX_API_BASE_URL=/ make build-prod
+RUN BASEHREF=___UTASK_DASHBOARD_BASEHREF___ PREFIX_API_BASE_URL=___UTASK_DASHBOARD_PREFIXAPIBASEURL___ make build-prod
 
 # editor
 WORKDIR /home/node/ui/editor
-RUN BASEHREF=/ui/editor/ make build-prod
+RUN BASEHREF=___UTASK_EDITOR_BASEHREF___ make build-prod
 
 FROM golang:1.13-buster
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_generateBaseHref(t *testing.T) {
+	assert.Equal(t, "/ui/dashboard/", generateBaseHref("", "/ui/dashboard/"))
+	assert.Equal(t, "/ui/dashboard/", generateBaseHref("/", "/ui/dashboard/"))
+	assert.Equal(t, "/ui/dashboard/", generateBaseHref("", "/ui/dashboard"))
+	assert.Equal(t, "/toto/ui/dashboard/", generateBaseHref("/toto", "/ui/dashboard/"))
+	assert.Equal(t, "/toto/ui/dashboard/", generateBaseHref("/toto/", "/ui/dashboard/"))
+}
+
+func Test_generateAPIPathPrefix(t *testing.T) {
+	assert.Equal(t, "/", generatePathPrefixAPI(""))
+	assert.Equal(t, "/", generatePathPrefixAPI("./"))
+	assert.Equal(t, "/", generatePathPrefixAPI("."))
+	assert.Equal(t, "/toto/", generatePathPrefixAPI("/toto"))
+	assert.Equal(t, "/toto/", generatePathPrefixAPI("/toto/"))
+
+}

--- a/api/static.go
+++ b/api/static.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	notWrittenSize = -1
+	defaultStatus  = http.StatusOK
+)
+
+// StaticFilePatternReplaceMiddleware is a middleware that modifies the response body with a given replace pattern
+// Used inside utask to change response body of static files at flight, to customize path prefixes.
+func StaticFilePatternReplaceMiddleware(oldnew ...string) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		buffer := &bytes.Buffer{}
+		originalWriter := c.Writer
+		wb := &responseWriter{
+			ResponseWriter: originalWriter,
+			status:         defaultStatus,
+			size:           notWrittenSize,
+			bufwriter:      buffer,
+		}
+		wb.replacer = strings.NewReplacer(oldnew...)
+		c.Writer = wb
+		c.Next()
+		str := wb.replacer.Replace(buffer.String())
+		wb.Header().Set("Content-Length", strconv.FormatInt(int64(len(str)), 10))
+		wb.WriteHeaderNow()
+		if _, err := originalWriter.WriteString(str); err != nil {
+			logrus.WithError(err).Error("unable to respond to static content")
+		}
+	}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	size      int64
+	status    int
+	replacer  *strings.Replacer
+	bufwriter *bytes.Buffer
+}
+
+// WriteHeader sends an HTTP response header with the provided
+// status code.
+func (w *responseWriter) WriteHeader(code int) {
+	if code <= 0 || w.status == code || w.Written() {
+		return
+	}
+
+	w.status = code
+}
+
+// WriteHeaderNow forces to write HTTP headers
+func (w *responseWriter) WriteHeaderNow() {
+	if w.Written() {
+		return
+	}
+
+	w.size = 0
+	w.ResponseWriter.WriteHeader(w.status)
+}
+
+// Write writes a given bytes array into the response buffer.
+func (w *responseWriter) Write(data []byte) (n int, err error) {
+	n, err = w.bufwriter.Write(data)
+	if err != nil {
+		logrus.WithError(err).Error("responseWriter: unable to write data")
+	}
+	w.size += int64(n)
+	return
+
+}
+
+// WriteString writes a given string into the response buffer.
+func (w *responseWriter) WriteString(s string) (n int, err error) {
+	n, err = io.WriteString(w.bufwriter, s)
+	if err != nil {
+		logrus.WithError(err).Error("responseWriter: unable to write string")
+	}
+	w.size += int64(n)
+	return
+}
+
+// Status returns the HTTP response status code of the current request.
+func (w *responseWriter) Status() int {
+	return w.status
+}
+
+// Size returns the number of bytes already written into the response http body.
+func (w *responseWriter) Size() int {
+	return int(w.size)
+}
+
+// Writter returns true if the response body was already written.
+func (w *responseWriter) Written() bool {
+	return w.size != notWrittenSize
+}
+
+// Hijack implements the http.Hijacker interface.
+func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if w.size < 0 {
+		w.size = 0
+	}
+	return w.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+// CloseNotify implements the http.CloseNotify interface.
+func (w *responseWriter) CloseNotify() <-chan bool {
+	return w.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
+// Flush implements the http.Flush interface.
+func (w *responseWriter) Flush() {
+	w.WriteHeaderNow()
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
+// Pusher implements the http.Pusher interface
+func (w *responseWriter) Pusher() (pusher http.Pusher) {
+	if pusher, ok := w.ResponseWriter.(http.Pusher); ok {
+		return pusher
+	}
+	return nil
+}

--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -118,6 +118,14 @@ var rootCmd = &cobra.Command{
 		server = api.NewServer()
 		server.WithAuth(defaultAuthHandler)
 
+		cfg, err := utask.Config(store)
+		if err != nil {
+			return err
+		}
+		server.SetDashboardPathPrefix(cfg.DashboardPathPrefix)
+		server.SetDashboardAPIPathPrefix(cfg.DashboardAPIPathPrefix)
+		server.SetEditorPathPrefix(cfg.EditorPathPrefix)
+
 		for _, err := range []error{
 			// register builtin executors
 			builtin.Register(),

--- a/utask.go
+++ b/utask.go
@@ -69,10 +69,10 @@ const (
 
 	// This is the key used in Values for a step to refer to itself
 	This = "this"
-)
 
-// UtaskCfgSecretAlias is the key for the config item containing global configuration data
-const UtaskCfgSecretAlias = "utask-cfg"
+	// UtaskCfgSecretAlias is the key for the config item containing global configuration data
+	UtaskCfgSecretAlias = "utask-cfg"
+)
 
 // Cfg holds global configuration data
 type Cfg struct {
@@ -86,6 +86,9 @@ type Cfg struct {
 	ConcealedSecrets        []string                 `json:"concealed_secrets"`
 	ResourceLimits          map[string]uint          `json:"resource_limits"`
 	MaxConcurrentExecutions uint                     `json:"max_concurrent_executions"`
+	DashboardPathPrefix     string                   `json:"dashboard_path_prefix"`
+	DashboardAPIPathPrefix  string                   `json:"dashboard_api_path_prefix"`
+	EditorPathPrefix        string                   `json:"editor_path_prefix"`
 
 	resourceSemaphores map[string]*semaphore.Weighted
 	executionSemaphore *semaphore.Weighted


### PR DESCRIPTION
When utask is deployed behind a ProxyPass, UIs need to be aware of where
they are currently running (which path prefix is prepended) & where API
is reachable.

Adding 3 new configuration variable to personalize it:
- dashboard_path_prefix
- dashboard_api_path_prefix
- editor_path_prefix

Dashboard & Editor UIs are served with path_prefix being rewritten at
flight.

Fixes #64