### PR TITLE
fix: config: dashboard prefix setter should be configured after Init plugins

### DIFF
--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -118,14 +118,6 @@ var rootCmd = &cobra.Command{
 		server = api.NewServer()
 		server.WithAuth(defaultAuthHandler)
 
-		cfg, err := utask.Config(store)
-		if err != nil {
-			return err
-		}
-		server.SetDashboardPathPrefix(cfg.DashboardPathPrefix)
-		server.SetDashboardAPIPathPrefix(cfg.DashboardAPIPathPrefix)
-		server.SetEditorPathPrefix(cfg.EditorPathPrefix)
-
 		for _, err := range []error{
 			// register builtin executors
 			builtin.Register(),
@@ -142,6 +134,14 @@ var rootCmd = &cobra.Command{
 				return err
 			}
 		}
+
+		cfg, err := utask.Config(store)
+		if err != nil {
+			return err
+		}
+		server.SetDashboardPathPrefix(cfg.DashboardPathPrefix)
+		server.SetDashboardAPIPathPrefix(cfg.DashboardAPIPathPrefix)
+		server.SetEditorPathPrefix(cfg.EditorPathPrefix)
 
 		if utask.FDebug {
 			log.SetLevel(log.DebugLevel)


### PR DESCRIPTION
If Init plugins are used to register new configstore providers, error message will be like

`FATA[2020-01-16T13:46:48Z] failed to get utask configuration from store: configstore: get first item (slice: utask-cfg): no item found `