### PR TITLE
chore: improve build and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 after_success:
   - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN # upload coverage.out results to goveralls plateform
   - git reset --hard HEAD  # reset go.mod and go.sum, modified by make test-travis
-  - make run-goreleaser # run goreleaser process
+  - test -n "${TRAVIS_TAG}" -a "${TRAVIS_GO_VERSION}" = "1.13" && make run-goreleaser # run goreleaser process
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ TEST_LOCATION	= ./...
 TEST_CMD		= go test -count=1 -v -mod=vendor -cover ${TEST_LOCATION}
 TEST_CMD_COV	= ${TEST_CMD} -covermode=count -coverprofile=coverage.out
 
+SOURCE_FILES 	= $(shell find ./ -type f -name "*.go" | grep -v _test.go)
+
 VERSION 		:= $(shell git describe --exact-match --abbrev=0 --tags $(git rev-list --tags --max-count=1) 2> /dev/null)
 ifndef VERSION
 	VERSION = $(shell git describe --abbrev=3 --tags $(git rev-list --tags --max-count=1))-dev
@@ -31,9 +33,9 @@ define docker_build
 	docker build ${DOCKER_OPT} -f ${MAIN_LOCATION}/$(1)/Dockerfile .
 endef
 
-all: ${BINARY} 
+all: ${BINARY}
 
-${BINARY}: 
+${BINARY}: $(SOURCE_FILES) go.mod
 	$(call build_binary,${BINARY})
 
 docker:
@@ -58,7 +60,7 @@ test-travis:
 	go get github.com/mattn/goveralls
 	hack/test.sh ${TEST_CMD_COV}
 
-test-docker: 
+test-docker:
 	DEV=true bash hack/test-docker.sh ${TEST_CMD}
 
 run-test-stack:


### PR DESCRIPTION
- Avoid releasing on every golang version + make sure we have a tag.
- Makefile now takes care of modified sources files while building.