### PR TITLE
fix: configstore: using DefaultStore instead of a new one

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -45,7 +45,7 @@ const (
 var hdl http.Handler
 
 func TestMain(m *testing.M) {
-	store := configstore.NewStore()
+	store := configstore.DefaultStore
 	store.InitFromEnvironment()
 
 	logrus.SetOutput(os.Stdout)

--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -107,7 +107,7 @@ var rootCmd = &cobra.Command{
 		utask.FDebug = viper.GetBool(envDebug)
 		utask.FMaintenanceMode = viper.GetBool(envMaintenance)
 
-		store = configstore.NewStore()
+		store = configstore.DefaultStore
 		store.InitFromEnvironment()
 
 		defaultAuthHandler, err := basicAuthHandler(store)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	store := configstore.NewStore()
+	store := configstore.DefaultStore
 	store.InitFromEnvironment()
 
 	db.Init(store)


### PR DESCRIPTION
Previously, we were using configstore.NewStore() but this is
incompatible with plugins that might need to validate some configuration
from configstore to validate template when importing.
Using configstore.DefaultStore makes sure that every plugins is
listening on the same configstore store.