### PR TITLE
fix: tasktemplates: Delete/Archive tasktemplate at import if they no longer exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY			= utask
 MAIN_LOCATION	= ./cmd
 
 TEST_LOCATION	= ./...
-TEST_CMD		= go test -count=1 -v -mod=vendor -parallel 1 ${TEST_LOCATION}
+TEST_CMD		= go test -count=1 -v -mod=vendor -cover -p 1 ${TEST_LOCATION}
 TEST_CMD_COV	= ${TEST_CMD} -covermode=count -coverprofile=coverage.out
 
 SOURCE_FILES 	= $(shell find ./ -type f -name "*.go" | grep -v _test.go)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY			= utask
 MAIN_LOCATION	= ./cmd
 
 TEST_LOCATION	= ./...
-TEST_CMD		= go test -count=1 -v -mod=vendor -cover ${TEST_LOCATION}
+TEST_CMD		= go test -count=1 -v -mod=vendor -parallel 1 ${TEST_LOCATION}
 TEST_CMD_COV	= ${TEST_CMD} -covermode=count -coverprofile=coverage.out
 
 SOURCE_FILES 	= $(shell find ./ -type f -name "*.go" | grep -v _test.go)

--- a/models/tasktemplate/fromdir_test.go
+++ b/models/tasktemplate/fromdir_test.go
@@ -1,0 +1,102 @@
+package tasktemplate_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/loopfz/gadgeto/zesty"
+	"github.com/ovh/configstore"
+	"github.com/ovh/utask"
+	"github.com/ovh/utask/db"
+	"github.com/ovh/utask/engine/step"
+	"github.com/ovh/utask/models/task"
+	"github.com/ovh/utask/models/tasktemplate"
+	"github.com/ovh/utask/pkg/now"
+	"github.com/ovh/utask/pkg/plugins/builtin/echo"
+	"github.com/ovh/utask/pkg/plugins/builtin/script"
+	pluginsubtask "github.com/ovh/utask/pkg/plugins/builtin/subtask"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	store := configstore.NewStore()
+	store.InitFromEnvironment()
+
+	logrus.SetOutput(os.Stdout)
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	step.RegisterRunner(echo.Plugin.PluginName(), echo.Plugin)
+	step.RegisterRunner(script.Plugin.PluginName(), script.Plugin)
+	step.RegisterRunner(pluginsubtask.Plugin.PluginName(), pluginsubtask.Plugin)
+
+	db.Init(store)
+
+	now.Init()
+
+	os.Exit(m.Run())
+}
+
+func TestLoadFromDir(t *testing.T) {
+	dbp, err := zesty.NewDBProvider(utask.DBName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tasktemplate.LoadFromDir(dbp, "templates_tests")
+	assert.Nil(t, err, "LoadFromDir failed")
+
+	taskTemplatesFromDatabase, err := tasktemplate.ListTemplates(dbp, true, 10, nil)
+	assert.Nil(t, err, "ListTemplates failed")
+	assert.Len(t, taskTemplatesFromDatabase, 2, "wrong size of imported templates")
+
+	tt := tasktemplate.TaskTemplate{}
+	tmpl, err := ioutil.ReadFile(path.Join("templates_tests", "hello-world-now.yaml"))
+	assert.Nil(t, err, "unable to read file hello-world-now.yaml")
+	err = yaml.Unmarshal(tmpl, &tt)
+	assert.Nil(t, err, "unable to unmarshal tasktemplate")
+
+	tt.Name = "a WONDERFUL new template"
+	tt.Normalize()
+
+	err = tt.Valid()
+	assert.Nil(t, err, "unable to valid new template")
+
+	err = dbp.DB().Insert(&tt)
+	assert.Nil(t, err, "unable to insert new template")
+
+	taskTemplatesFromDatabase, err = tasktemplate.ListTemplates(dbp, true, 10, nil)
+	assert.Nil(t, err, "ListTemplates failed")
+	assert.Len(t, taskTemplatesFromDatabase, 3, "wrong size of imported templates")
+
+	err = tasktemplate.LoadFromDir(dbp, "templates_tests")
+	assert.Nil(t, err, "LoadFromDir failed")
+
+	taskTemplatesFromDatabase, err = tasktemplate.ListTemplates(dbp, true, 10, nil)
+	assert.Nil(t, err, "ListTemplates failed")
+	assert.Len(t, taskTemplatesFromDatabase, 2, "wrong size of imported templates")
+
+	tt.ID = 0
+	err = dbp.DB().Insert(&tt)
+	assert.Nil(t, err, "unable to insert new template")
+
+	_, err = task.Create(dbp, &tt, "admin", []string{}, []string{}, map[string]interface{}{}, nil)
+	assert.Nil(t, err, "unable to create task")
+
+	err = tasktemplate.LoadFromDir(dbp, "templates_tests")
+	assert.Nil(t, err, "LoadFromDir failed")
+
+	taskTemplatesFromDatabase, err = tasktemplate.ListTemplates(dbp, true, 10, nil)
+	assert.Nil(t, err, "ListTemplates failed")
+	assert.Len(t, taskTemplatesFromDatabase, 3, "wrong size of imported templates")
+
+	tt2, err := tasktemplate.LoadFromName(dbp, tt.Name)
+	assert.Nil(t, err, "unable to load tt2")
+	assert.False(t, tt.Hidden, "previous template should have not been hidden")
+	assert.False(t, tt.Blocked, "previous template should have not been blocked")
+	assert.True(t, tt2.Hidden, "template should have been hidden as not existing in dir but have linked task")
+	assert.True(t, tt2.Blocked, "template should have been blocked as not existing in dir but have linked task")
+}

--- a/models/tasktemplate/fromdir_test.go
+++ b/models/tasktemplate/fromdir_test.go
@@ -46,6 +46,15 @@ func TestLoadFromDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = dbp.DB().Query("DELETE FROM resolution;")
+	assert.Nil(t, err, "Emptying database failed")
+	_, err = dbp.DB().Query("DELETE FROM task_comment;")
+	assert.Nil(t, err, "Emptying database failed")
+	_, err = dbp.DB().Query("DELETE FROM task;")
+	assert.Nil(t, err, "Emptying database failed")
+	_, err = dbp.DB().Query("DELETE FROM task_template;")
+	assert.Nil(t, err, "Emptying database failed")
+
 	err = tasktemplate.LoadFromDir(dbp, "templates_tests")
 	assert.Nil(t, err, "LoadFromDir failed")
 

--- a/models/tasktemplate/templates_tests/a-hello-world-now.yaml
+++ b/models/tasktemplate/templates_tests/a-hello-world-now.yaml
@@ -1,0 +1,53 @@
+name: a-hello-world-now
+description: Say hello to the world, now!
+long_description: This task prints out a greeting to the entire world, after retrieving the current UTC time from an external API
+doc_link: https://en.wikipedia.org/wiki/%22Hello,_World!%22_program
+
+title_format: Say hello in {{.input.language}}
+result_format:
+  echo_message: "{{.step.sayHello.output.message}}"
+  echo_when: "{{.step.sayHello.output.when}}"
+
+allowed_resolver_usernames: []
+allow_all_resolver_usernames: true
+auto_runnable: true
+blocked: false
+hidden: false
+
+variables:
+  - name: english-message
+    value: Hello World!
+  - name: spanish-message
+    expression: |-
+      // a short javascript snippet
+      var h = 'Hola';
+      var m = 'mundo';
+      h + ' ' + m + '!';
+
+inputs:
+  - name: language
+    description: The language in which you wish to greet the world
+    legal_values: [english, spanish]
+    optional: true
+    default: english
+
+steps:
+  sayHello:
+    description: Echo a greeting in your language of choice
+    action:
+      type: echo
+      configuration:
+        output:
+          message: >-
+            {{if (eq .input.language "english")}}{{eval "english-message"}}
+            {{else if (eq .input.language "spanish")}}{{eval "spanish-message"}}{{end}}
+  sayHello2:
+    description: Echo a greeting in your language of choice
+    action:
+      type: subtask
+      configuration:
+        # a template that must already be registered on this instance of µTask
+        template: hello-world-now
+        # valid input, as defined by the referred template
+        # optionally, a list of users which are authorized to resolve this specific task
+        resolver_usernames: admin

--- a/models/tasktemplate/templates_tests/hello-world-now.yaml
+++ b/models/tasktemplate/templates_tests/hello-world-now.yaml
@@ -1,0 +1,43 @@
+name: hello-WORLD-now
+description: Say hello to the world, now!
+long_description: This task prints out a greeting to the entire world, after retrieving the current UTC time from an external API
+doc_link: https://en.wikipedia.org/wiki/%22Hello,_World!%22_program
+
+title_format: Say hello in {{.input.language}}
+result_format:
+  echo_message: "{{.step.sayHello.output.message}}"
+  echo_when: "{{.step.sayHello.output.when}}"
+
+allowed_resolver_usernames: []
+allow_all_resolver_usernames: true
+auto_runnable: true
+blocked: false
+hidden: false
+
+variables:
+  - name: english-message
+    value: Hello World!
+  - name: spanish-message
+    expression: |-
+      // a short javascript snippet
+      var h = 'Hola';
+      var m = 'mundo';
+      h + ' ' + m + '!';
+
+inputs:
+  - name: language
+    description: The language in which you wish to greet the world
+    legal_values: [english, spanish]
+    optional: true
+    default: english
+
+steps:
+  sayHello:
+    description: Echo a greeting in your language of choice
+    action:
+      type: echo
+      configuration:
+        output:
+          message: >-
+            {{if (eq .input.language "english")}}{{eval "english-message"}}
+            {{else if (eq .input.language "spanish")}}{{eval "spanish-message"}}{{end}}


### PR DESCRIPTION
This will remove tasktemplate from database if the specified template is not in templates folder anymore.
Fixing any problems of remaining templates after being deleted from templates folder.
If tasktemplate still linked to some tasks, then it's hold inside the database, but with flag `hidden` and `blocked` to prevent regular users from using it.