### PR TITLE
Adds some features on SSH/script plugin and fixing some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,13 @@ func exec(stepName string, config interface{}, ctx interface{}) (output interfac
 }
 ```
 
+`Exec` function returns 3 values:
+- `output`: an object representing the output of the plugin, that will be usable as `{{.step.xxx.output}}` in the templating engine.
+- `metadata`: an object representing the metadata of the plugin, that will be usable as `{{.step.xxx.metadata}}` in the templating engine.
+- `err`: an error if the execution of the plugin failed. uTask is based on `github.com/juju/errors` package to determine if the returned error is a `CLIENT_ERROR` or a `SERVER_ERROR`.
+
+__Warning: `output` and `metadata` should not be named structures but plain map. Otherwise, you might encounter some inconsistencies in templating as keys could be different before and after marshalling in database.__
+
 ### Init Plugins
 
 Init plugins allow you to customize your instance of µtask by giving you access to its underlying configuration store and its API server.

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ func exec(stepName string, config interface{}, ctx interface{}) (output interfac
 - `metadata`: an object representing the metadata of the plugin, that will be usable as `{{.step.xxx.metadata}}` in the templating engine.
 - `err`: an error if the execution of the plugin failed. uTask is based on `github.com/juju/errors` package to determine if the returned error is a `CLIENT_ERROR` or a `SERVER_ERROR`.
 
-__Warning: `output` and `metadata` should not be named structures but plain map. Otherwise, you might encounter some inconsistencies in templating as keys could be different before and after marshalling in database.__
+__Warning: `output` and `metadata` should not be named structures but plain map. Otherwise, you might encounter some inconsistencies in templating as keys could be different before and after marshalling in the database.__
 
 ### Init Plugins
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -639,17 +639,17 @@ func TestScriptPlugin(t *testing.T) {
 	payload["dumb_string"] = fmt.Sprintf("Hello %s!", argv)
 	payload["random_object"] = map[string]interface{}{"foo": "bar"}
 
-	metadata := script.Metadata{
-		ExitCode:      "0",
-		ProcessState:  "exit status 0",
-		Output:        "Hello world script\n{\"dumb_string\":\"Hello world!\",\"random_object\":{\"foo\":\"bar\"}}\n",
-		ExecutionTime: "",
-		Error:         "",
+	metadata := map[string]interface{}{
+		"exit_code":      "0",
+		"process_state":  "exit status 0",
+		"output":         "Hello world script\n{\"dumb_string\":\"Hello world!\",\"random_object\":{\"foo\":\"bar\"}}\n",
+		"execution_time": "",
+		"error":          "",
 	}
 
 	// because time can't be consistant through tests
-	metadataOutput := res.Steps["stepOne"].Metadata.(script.Metadata)
-	metadataOutput.ExecutionTime = ""
+	metadataOutput := res.Steps["stepOne"].Metadata.(map[string]interface{})
+	metadataOutput["execution_time"] = ""
 
 	assert.Equal(t, payload, res.Steps["stepOne"].Payload)
 	assert.Equal(t, metadata, metadataOutput)

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -131,7 +131,7 @@
                             "description": "Action configuration"
                         },
                         "base_configuration": {
-                            "type": "object"
+                            "type": "string"
                         },
                         "base_output": {
                             "type": "object"
@@ -232,7 +232,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -271,7 +271,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -312,7 +312,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -378,7 +378,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -397,6 +397,9 @@
                 "configuration": {
                     "type": "object",
                     "additionalProperties": false,
+                    "required": [
+                        "template"
+                    ],
                     "properties": {
                         "template": {
                             "type": "string"
@@ -410,7 +413,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -444,7 +447,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -479,7 +482,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -544,7 +547,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -589,7 +592,7 @@
                     }
                 },
                 "base_configuration": {
-                    "type": "object"
+                    "type": "string"
                 },
                 "base_output": {
                     "type": "object"
@@ -602,6 +605,11 @@
         "Condition": {
             "type": "object",
             "additionalProperties": false,
+            "required": [
+                "type",
+                "if",
+                "then"
+            ],
             "properties": {
                 "type": {
                     "type": "string",
@@ -615,6 +623,12 @@
                     "type": "array",
                     "items": {
                         "type": "object",
+                        "required": [
+                            "expected",
+                            "operator",
+                            "value"
+                        ],
+                        "additionalProperties": false,
                         "properties": {
                             "value": {
                                 "type": "string",
@@ -671,10 +685,7 @@
             ],
             "required": [
                 "name",
-                "description",
-                "legal_values",
-                "optional",
-                "default"
+                "description"
             ],
             "properties": {
                 "name": {

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -358,6 +358,22 @@
                         },
                         "allow_exit_non_zero": {
                             "type": "boolean"
+                        },
+                        "output_manual_delimiters": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "output_mode": {
+                            "type": "string",
+                            "enum": [
+                                "disabled",
+                                "auto-result",
+                                "manual-delimiters",
+                                "manual-lastline"
+                            ],
+                            "default": "auto-result"
                         }
                     }
                 },

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -356,8 +356,12 @@
                         "ssh_key_passphrase": {
                             "type": "string"
                         },
-                        "allow_exit_non_zero": {
-                            "type": "boolean"
+                        "exit_codes_unrecoverable": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": "^(\\d+)(?:-(\\d+))?$"
+                            }
                         },
                         "output_manual_delimiters": {
                             "type": "array",

--- a/models/tasktemplate/template.go
+++ b/models/tasktemplate/template.go
@@ -102,7 +102,7 @@ func create(dbp zesty.DBProvider, tt *TaskTemplate) (*TaskTemplate, error) {
 
 // LoadFromName returns a task template, given its unique human-readable identifier
 func LoadFromName(dbp zesty.DBProvider, name string) (tt *TaskTemplate, err error) {
-	defer errors.DeferredAnnotatef(&err, "Failed to load template from name")
+	defer errors.DeferredAnnotatef(&err, "Failed to load template %q from name", name)
 
 	query, params, err := ttSelector.Where(
 		squirrel.Eq{`"task_template".name`: name},
@@ -122,7 +122,7 @@ func LoadFromName(dbp zesty.DBProvider, name string) (tt *TaskTemplate, err erro
 // LoadFromID returns a task template, given its "private" identifier
 // A shortcut only used internally, not exposed through API
 func LoadFromID(dbp zesty.DBProvider, id int64) (tt *TaskTemplate, err error) {
-	defer errors.DeferredAnnotatef(&err, "Failed to load template from name")
+	defer errors.DeferredAnnotatef(&err, "Failed to load template from ID %d", id)
 
 	query, params, err := ttSelector.Where(
 		squirrel.Eq{`"task_template".id`: id},

--- a/pkg/plugins/builtin/notify/notify.go
+++ b/pkg/plugins/builtin/notify/notify.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -42,6 +43,10 @@ func validConfig(config interface{}) error {
 	// The slice must be sorted in ascending order
 	// From https://golang.org/pkg/sort/#SearchStrings
 	sort.Strings(snames)
+
+	if len(snames) == 0 {
+		return errors.New("registered notify senders list is empty")
+	}
 
 	for _, backend := range cfg.Backends {
 		i := sort.SearchStrings(snames, backend)

--- a/pkg/plugins/builtin/script/script.go
+++ b/pkg/plugins/builtin/script/script.go
@@ -24,6 +24,14 @@ var (
 	)
 )
 
+const (
+	exitCodeMetadataKey      string = "exit_code"
+	processStateMetadataKey  string = "process_state"
+	outputMetadataKey        string = "output"
+	executionTimeMetadataKey string = "execution_time"
+	errorMetadataKey         string = "error"
+)
+
 // Metadata represents the metadata of script execution
 type Metadata struct {
 	ExitCode      string `json:"exit_code"`
@@ -117,12 +125,12 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 
 	outStr := string(out)
 
-	metadata := Metadata{
-		ExitCode:      fmt.Sprint(exitCode),
-		ProcessState:  pState,
-		Output:        outStr,
-		ExecutionTime: execTime.String(),
-		Error:         metaError,
+	metadata := map[string]interface{}{
+		exitCodeMetadataKey:      fmt.Sprint(exitCode),
+		processStateMetadataKey:  pState,
+		outputMetadataKey:        outStr,
+		executionTimeMetadataKey: execTime.String(),
+		errorMetadataKey:         metaError,
 	}
 
 	if !cfg.AllowExitNonZero && exitCode != 0 {

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -2,6 +2,8 @@
 
 This plugin connects to a remote system and performs a block of commands. It can extract variables from the shell back to the output of its enclosing step.
 
+The step will be considered successful if the script returns exit code 0, otherwise, it will be considered as a `SERVER_ERROR` (and will be retried). For unrecoverable errors (for instance, invalid parameters), it is possible to configure a list of exit codes (see `exit_codes_unrecoverable`) that should halt the execution (`CLIENT_ERROR`).
+
 ## Configuration
 
 |Fields|Description
@@ -10,12 +12,12 @@ This plugin connects to a remote system and performs a block of commands. It can
 | `target` | address of the remote machine
 | `hops` | a list of intermediate addresses (bastions)
 | `script` | multiline text, commands to be run on the machine's shell
-| `output_mode` | indicates how to retrieve output values ; valid values are: `auto-result` (default), `disabled`, `manual-delimiters`, `manual-lastline`
+| `output_mode` | indicates how to retrieve the output values ; valid values are: `auto-result` (default), `disabled`, `manual-delimiters`, `manual-lastline`
 | `result` | an object to extract the values of variables from the machine's shell (only used when `output_mode` is configured to `auto-result`)
 | `output_manual_delimiters` | array of 2 strings ; look for a JSON formatted string in the script output between specific delimiters (only used when `output_mode` is configured to `manual-delimiters`)
 | `ssh_key` | private ssh key, preferrably retrieved from {{.config}}
 | `ssh_key_passphrase` | passphrase for the key, if any
-| `allow_exit_non_zero` | allow a non-zero exit code to be considered as a successful step (bool default `false`)
+| `exit_codes_unrecoverable` | a list of non-zero exit codes (1, 2, 3, ...) or ranges (1-10, ...) which should be considered unrecoverable and halt execution ; these will be returned to the main engine as a `CLIENT_ERROR`
 
 ## Example
 
@@ -36,6 +38,7 @@ action:
     script: |-
       PID=$(systemctl show --property MainPID {{.input.serviceName}} | cut -d= -f2)
       SERVICE_UPTIME=$(ps -h -p ${PID} -o etimes)
+    # this is the default mode
     output_mode: auto-result
     # value extraction
     result:
@@ -45,6 +48,10 @@ action:
     ssh_key: '{{.config.mySSHKey}}'
     # optional delimiters to look for an output -- requires output_mode set to manual-delimiters
     #output_manual_delimiters: ["JSON_START", "JSON_END"]
+    exit_codes_unrecoverable:
+      - "1-10"
+      - "100"
+      - "110"
 ```
 
 ## Requirements
@@ -67,7 +74,7 @@ The `Metadata` to fetch informations about plugin execution:
 ```json
 {
   "output": "Connecting...\nWelcome to Ubuntu 19.04 (GNU/Linux ... x86_64)\n[...]\n{\"pid\":\"3931\",\"service_name\":\"nginx\",\"service_uptime\":\"1715606\"}",
-  "exit_status": "0",
+  "exit_code": "0",
   "exit_signal": "0",
   "exit_msg": "exited 0"
 }

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -10,7 +10,9 @@ This plugin connects to a remote system and performs a block of commands. It can
 | `target` | address of the remote machine
 | `hops` | a list of intermediate addresses (bastions)
 | `script` | multiline text, commands to be run on the machine's shell
-| `result` | an object to extract the values of variables from the machine's shell
+| `output_mode` | indicates how to retrieve output values ; valid values are: `auto-result` (default), `disabled`, `manual-delimiters`, `manual-lastline`
+| `result` | an object to extract the values of variables from the machine's shell (only used when `output_mode` is configured to `auto-result`)
+| `output_manual_delimiters` | array of 2 strings ; look for a JSON formatted string in the script output between specific delimiters (only used when `output_mode` is configured to `manual-delimiters`)
 | `ssh_key` | private ssh key, preferrably retrieved from {{.config}}
 | `ssh_key_passphrase` | passphrase for the key, if any
 | `allow_exit_non_zero` | allow a non-zero exit code to be considered as a successful step (bool default `false`)
@@ -34,12 +36,15 @@ action:
     script: |-
       PID=$(systemctl show --property MainPID {{.input.serviceName}} | cut -d= -f2)
       SERVICE_UPTIME=$(ps -h -p ${PID} -o etimes)
+    output_mode: auto-result
     # value extraction
-    result: 
+    result:
       pid: $PID
       uptime: $SERVICE_UPTIME
     # credentials
     ssh_key: '{{.config.mySSHKey}}'
+    # optional delimiters to look for an output -- requires output_mode set to manual-delimiters
+    #output_manual_delimiters: ["JSON_START", "JSON_END"]
 ```
 
 ## Requirements

--- a/pkg/plugins/builtin/ssh/ssh.go
+++ b/pkg/plugins/builtin/ssh/ssh.go
@@ -50,10 +50,6 @@ func configssh(i interface{}) error {
 		return errors.New("missing ssh target")
 	}
 
-	if cfg.Script == "" {
-		return errors.New("missing ssh script")
-	}
-
 	if cfg.Key == "" {
 		return errors.New("missing ssh key")
 	}


### PR DESCRIPTION
* fddc3ff  feat: ssh: Add no_trap_injection and output_delimiters parameters. 16 hours ago [Romain Beuque]
* 1bc3c0b  fix: ssh: changing script to be optional 17 hours ago [Romain Beuque]
* 07eb4a7  fix: script plugin should return metadata in a map[string]string to have consistent keys 17 hours ago [Romain Beuque]
* b0a5362  fix: notify pluggin panic when backend declared in template while no backends declared in utask-cfg 17 hours ago [Romain Beuque]
* 7c4a01c  chore: rewrote error messages when failed to load templates (added more information on which failed) 17 hours ago [Romain Beuque]
