### PR TITLE
HTTP plugin: default timeout of 30s + method PATCH

### DIFF
--- a/pkg/plugins/builtin/http/README.md
+++ b/pkg/plugins/builtin/http/README.md
@@ -1,19 +1,21 @@
 # `http` Plugin
 
-This plugin permorms an http request.
+This plugin permorms an HTTP request.
 
 ## Configuration
 
 |Fields|Description
 |---|---
-| `url` | destination for the http call, including host, path and query params
-| `method` | http method (GET/POST/PUT/DELETE)
+| `url` | destination for the http call, including host, path and query params; this all-in-one field conflicts with `host` and `path`
+| `host` |  destination host for the http call; this field conflicts with the all-in-one field `url`
+| `path` | path for the http call; to use jointly with the `host` field; this field conflicts with the all-in-one field `url`
+| `method` | http method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)
 | `body` | a string representing the payload to be sent with the request
-| `headers` | a list of headers, represented as objects composed of `name` and `value`
-| `timeout_seconds` | an unsigned int representing a custom HTTP client timeout in seconds
+| `headers` | a list of headers, represented as (`name`, `value`) pairs
+| `timeout` | timeout expressed as a duration (e.g. `30s`)
 | `auth` | a single object composed of either a `basic` object with `user` and `password` fields to enable HTTP basic auth, or `bearer` field to enable Bearer Token Authorization 
-| `deny_redirects` | a boolean representing the policy of redirects
-| `parameters` | a list of HTTP query parameters, represented as objects composed of `key` and `value`
+| `follow_redirect` | if `true` (string) the plugin will follow up to 10 redirects (302, ...)
+| `query_parameters` | a list of query parameters, represented as (`name`, `value`) pairs; these will appended the query parameters present in the `url` field; parameters can be repeated (in either `url` or `query_parameters`) which will produce e.g. `?param=value1&param=value2`
 | `trim_prefix`| prefix in the response that must be removed before unmarshalling (optional)
 
 ## Example
@@ -25,22 +27,22 @@ action:
   type: http
   configuration:
     # mandatory, string
-    url: http://example.org/user
+    url: http://example.org/user?lang=en
     # mandatory, string
     method: POST
-    # optional, string as uint16
-    timeout_seconds: "5"
-    # optional, authentication you can user either basic or bearer auth
+    # optional, string as duration
+    timeout: "5s"
+    # optional, authentication you can use either basic or bearer auth
     auth:
       basic: 
         user: {{.config.basicAuth.user}}
         password: {{.config.basicAuth.password}}
       bearer: {{.config.auth.token}}
     # optional, string as boolean
-    deny_redirects: "false"
-    # optional, array of key and value fields
-    parameters:
-    - key: foo
+    follow_redirect: "true"
+    # optional, array of name and value fields
+    query_parameters:
+    - name: foo
       value: bar
     # optional, array of name and value fields
     headers:
@@ -55,4 +57,4 @@ action:
 
 ## Requirements
 
-None by default. Sensitive data should be retrieved from configstore and accessed through `{{.config.[itemKey]}}` rather than hardcoded in your template.
+None by default. Sensitive data should stored in the configuration and accessed through `{{.config.[itemKey]}}` rather than hardcoded in your template.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Introduce a default timeout in the HTTP plugin (30s).
Clean up the HTTP plugin by moving some implem details into the httputil pkg.
Support the PATCH method.

* **What is the current behavior?** (You can also link to an open issue here)
No default timeout.
PATCH not supported.


* **What is the new behavior (if this is a feature change)?**
Timeout if none is supplied: 30s


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Timeout is now expressed as a duration, and named accordingly.
Also less importantly: http.NewHTTPClient has moved to httputil. As it was, it shouldnt have been public within the http pkg.


* **Other information**:
