### PR TITLE
fix: engine: children step now picked-up after being expanded

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -520,6 +520,25 @@ func TestForeach(t *testing.T) {
 	assert.Equal(t, "foo-b-bar-b", firstItemOutput["concat"])
 }
 
+func TestForeachWithPreRun(t *testing.T) {
+	input := map[string]interface{}{}
+	res, err := createResolution("foreachAndPreRun.yaml", input, nil)
+	require.Nilf(t, err, "expecting nil error, got %s", err)
+	require.NotNil(t, res)
+
+	res, err = runResolution(res)
+
+	require.Nilf(t, err, "got error %s", err)
+	require.NotNil(t, res)
+	assert.Equal(t, resolution.StateDone, res.State)
+	for _, st := range []string{"stepForeachNoDep", "stepSkippedNoDep", "stepNoDep", "stepForeachWithDep", "stepSkippedWithDep"} {
+		assert.Equal(t, step.StateDone, res.Steps[st].State)
+	}
+	for _, st := range []string{"stepDep", "stepDep2"} {
+		assert.Equal(t, step.StatePrune, res.Steps[st].State)
+	}
+}
+
 func TestVariables(t *testing.T) {
 	res, err := createResolution("variables.yaml", map[string]interface{}{}, nil)
 	assert.NotNil(t, res)

--- a/engine/templates_tests/foreachAndPreRun.yaml
+++ b/engine/templates_tests/foreachAndPreRun.yaml
@@ -1,0 +1,90 @@
+name            : foreachAndPreRun
+title_format    : 'validating that foreach steps and skip conditions are working seamlessly'
+description     : 'validating that foreach steps and skip conditions are working seamlessly'
+
+auto_runnable: true
+allow_all_resolver_usernames: true
+allowed_resolver_tokens: []
+allowed_resolver_usernames: []
+
+
+steps:
+  stepForeachNoDep:
+    description: a foreach step without any dep
+    foreach: '["1","2"]'
+    action:
+      type: echo
+      configuration:
+        output:
+          url: 'https://eu.httpbin.org/delay/{{ .iterator }}'
+  stepSkippedNoDep:
+    description: a skipped step without any dep
+    action:
+      type: echo
+      configuration:
+        output:
+          url: 'https://eu.httpbin.org/delay/1'
+    conditions:
+      - type: skip
+        if:
+          - value: 'foo'
+            operator: EQ
+            expected: 'foo'
+        then:
+          this: DONE
+  stepNoDep:
+    description: a regular step without any dep
+    action:
+      type: echo
+      configuration:
+        output:
+          url: 'https://eu.httpbin.org/delay/1'
+  stepForeachWithDep:
+    dependencies: [stepNoDep]
+    description: a foreach step with dep
+    foreach: '["1","2"]'
+    action:
+      type: echo
+      configuration:
+        output:
+          url: 'https://eu.httpbin.org/delay/{{ .iterator }}'
+  stepSkippedWithDep:
+    dependencies: [stepNoDep]
+    description: a skipped step with dep
+    action:
+      type: echo
+      configuration:
+        output:
+          url: 'https://eu.httpbin.org/delay/1'
+    conditions:
+      - type: skip
+        if:
+          - value: 'foo'
+            operator: EQ
+            expected: 'foo'
+        then:
+          this: DONE
+  stepDep:
+    dependencies: [stepNoDep]
+    description: a regular step with dep
+    action:
+      type: echo
+      configuration:
+        output:
+          url: 'https://eu.httpbin.org/delay/1'
+    conditions:
+      - type: skip
+        if:
+          - value: 'foo'
+            operator: EQ
+            expected: 'foo'
+        then:
+          this: PRUNE
+  stepDep2:
+    dependencies: [stepDep]
+    description: a regular step with dep
+    action:
+      type: echo
+      configuration:
+        output:
+          url: 'https://eu.httpbin.org/delay/1'


### PR DESCRIPTION
Expanded newly created steps were not injected when re-looking for
availableSteps after a step being expanded, which caused some
BLOCKED_DEADLOCK workflow.
    
Issue happened when a concurrent step was skipped with a pre-run
condition.