### PR TITLE
engine/step: Steps circular dependency check may fail on 2nd level de…

### DIFF
--- a/engine/step/stepcondition.go
+++ b/engine/step/stepcondition.go
@@ -102,6 +102,13 @@ func dependenciesChain(steps map[string]*Step, dependencies []string) []string {
 	}
 
 	for i := 0; i < len(chain); i++ {
+		if steps[chain[i]] == nil {
+			// 2nd level dependency may not exist
+			// if that happens when validating a step, then that probably means that
+			// the direct dependency has not been validated yet (non deterministic order).
+			// continue to fail gracefully later
+			continue
+		}
 		for _, stepDep := range steps[chain[i]].Dependencies {
 			s, _ := DependencyParts(stepDep)
 


### PR DESCRIPTION
…pendencies (non deterministic order): fix

Signed-off-by: Thomas Schaffer <thomas.schaffer@corp.ovh.com>

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When checking step circular dependencies, the order in which steps are inspected is not deterministic. As such, not all steps may have been previously validated (== all dependencies reference valid steps).
The current implementation naively uses step->dep1->dep2->XXX. Dep2 is nil, and it panics.


* **What is the new behavior (if this is a feature change)?**
Fail gracefully by continue'ing to let all step validations proceed, and eventually return the proper error (dep1: dep2 doesnt exist).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
