### PR TITLE
fix: unmarshaling of database config can lead to wrong default values

### DIFF
--- a/utask.go
+++ b/utask.go
@@ -127,9 +127,9 @@ type NotifyActionsParameters struct {
 
 // DatabaseConfig holds configuration to fine-tune DB connection
 type DatabaseConfig struct {
-	MaxOpenConns    int    `json:"max_open_conns"`
-	MaxIdleConns    int    `json:"max_idle_conns"`
-	ConnMaxLifetime int    `json:"conn_max_lifetime"`
+	MaxOpenConns    *int   `json:"max_open_conns"`
+	MaxIdleConns    *int   `json:"max_idle_conns"`
+	ConnMaxLifetime *int   `json:"conn_max_lifetime"`
 	ConfigName      string `json:"config_name"`
 }
 


### PR DESCRIPTION
The fields MaxOpenConns, MaxIdleConns, ConnMaxLifetime are set to the
zero-value of their type during unmarshaling when no input value is
provided in the configuration, which lead to the default values not
being used. Replace the fields with pointers to distinguish the zero
value and use the default when appropriate.