### PR TITLE
Fix: engine/values: Better handling of nil and/or empty values

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ The following templating functions are available:
 |**`Golang`** | Builtin functions from Golang text template  | [Doc](https://golang.org/pkg/text/template/#hdr-Actions)
 |**`Sprig`** | Extended set of functions from the Sprig project  | [Doc](https://masterminds.github.io/sprig/)
 |**`field`** | Equivalent to the dot notation, for entries with forbidden characters | ``{{field `config` `foo.bar`}}``
-|**`jsonmarshal`** | Used as part of a templating pipeline, outputs a JSON representation | ``{{.step.foo.output.bar \| jsonmarshal}}``
-|**`jsonfield`** | Similar to **field**, outputs a JSON representation | ``{{jsonfield `foo` `bar`}}``
 |**`eval`** | Evaluates the value of a template variable | ``{{eval `var1`}}``
 
 ### Basic properties
@@ -436,7 +434,7 @@ The following output can be expected to be accessible at `{{.step.prefixStrings.
 
 This output can be then passed to another step in json format:
 ```yaml
-foreach: '{{.step.prefixStrings.children | jsonmarshal}}'
+foreach: '{{.step.prefixStrings.children | toJson}}'
 ```
 
 ### Task templates validation

--- a/engine/templates_tests/foreach.yaml
+++ b/engine/templates_tests/foreach.yaml
@@ -14,7 +14,7 @@ steps:
                 output: {foo: bar}
     generateItems:
         description: generate list for next step
-        foreach: '{{.input.list | jsonmarshal}}'
+        foreach: '{{.input.list | toJson}}'
         conditions:
             - type: skip
               if:
@@ -39,7 +39,7 @@ steps:
     concatItems:
         description:  transform a list of items
         dependencies: [generateItems]
-        foreach: '{{.step.generateItems.children | jsonmarshal}}'
+        foreach: '{{.step.generateItems.children | toJson}}'
         conditions:
             - type: check
               if:

--- a/engine/templates_tests/jsonTemplating.yaml
+++ b/engine/templates_tests/jsonTemplating.yaml
@@ -19,6 +19,6 @@ steps:
           my-json-body: >
             {
               "single": "{{.input.singleString}}",
-              "singleMarshalled": {{.input.singleString | jsonmarshal}},
-              "multiline": {{.input.multilineString | jsonmarshal}}
+              "singleMarshalled": {{.input.singleString | toJson}},
+              "multiline": {{.input.multilineString | toJson}}
             }

--- a/engine/templates_tests/jsonnumber.yaml
+++ b/engine/templates_tests/jsonnumber.yaml
@@ -26,7 +26,7 @@ steps:
   loopStep:
     description: apply numbers to configuration
     dependencies: [listStep]
-    foreach: '{{.step.listStep.output | jsonmarshal}}'
+    foreach: '{{.step.listStep.output | toJson}}'
     action:
       type: echo
       configuration:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Consistency fixes around templating nil or empty values


* **What is the current behavior?** (You can also link to an open issue here)
SetOutput(step, nil) can be problematic -- it stores a nil element in the values map which may trigger errors in the templating instead of a graceful handling of an empty value (with access to `default` templating function, etc.).
The `field` templating function behaves differently than the dot notation: it returns the litteral `<no value>` which is considered true in templating pipelines, thus not compatible with functions like `default`.


* **What is the new behavior (if this is a feature change)?**
SetOutput and other functions setting step data now avoid setting nil values, replacing them with an empty map.
The field templating function now returns a reflect.Value similar to builtin functions inside text template. This allows us to return a zero-value reflect.Value when not found, which properly evals to false inside templating pipelines (`default` function ok), and prints to `<no value>` outside of templating pipelines.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
`fieldjson` and `jsonmarshal` were also problematic. Since they are redundant with built-in sprig functions (`toJson`, ... http://masterminds.github.io/sprig/defaults.html ), they got removed.


* **Other information**:
