### PR TITLE
remove: step.Payload removed, since it was deprecated for a long time

### DIFF
--- a/api/handler/resolution.go
+++ b/api/handler/resolution.go
@@ -140,7 +140,7 @@ type getResolutionIn struct {
 	PublicID string `path:"id, required"`
 }
 
-// GetResolution returns a single resolution, with its full content (all step payloads included)
+// GetResolution returns a single resolution, with its full content (all step outputs included)
 func GetResolution(c *gin.Context, in *getResolutionIn) (*resolution.Resolution, error) {
 	dbp, err := zesty.NewDBProvider(utask.DBName)
 	if err != nil {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -454,8 +454,8 @@ func TestInputNumber(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, res)
 
-	payload := res.Steps["stepOne"].Output.(map[string]interface{})
-	assert.Equal(t, "-2.3", payload["value"])
+	output := res.Steps["stepOne"].Output.(map[string]interface{})
+	assert.Equal(t, "-2.3", output["value"])
 }
 
 func TestAnyDependency(t *testing.T) {
@@ -467,8 +467,8 @@ func TestAnyDependency(t *testing.T) {
 	assert.NotNil(t, res)
 	assert.Nil(t, err)
 
-	payload := res.Steps["secondStepRunsIfAny"].Output.(map[string]interface{})
-	assert.Equal(t, "yes", payload["i_ran_anyway"])
+	output := res.Steps["secondStepRunsIfAny"].Output.(map[string]interface{})
+	assert.Equal(t, "yes", output["i_ran_anyway"])
 
 	thirdOKState := res.Steps["thirdStepRunsIfSecondOK"].State
 	assert.Equal(t, step.StateDone, thirdOKState)
@@ -548,13 +548,13 @@ func TestVariables(t *testing.T) {
 	assert.NotNil(t, res)
 	assert.Nil(t, err)
 
-	payload := res.Steps["renderVariables"].Output.(map[string]interface{})
-	assert.Equal(t, "4", payload["truc"])
-	assert.Equal(t, "5", payload["bidule"])
-	assert.Equal(t, "Hello World!", payload["templated"])
-	assert.Equal(t, "6", payload["cached"])
-	payload = res.Steps["renderVariablesWithCache"].Output.(map[string]interface{})
-	assert.Equal(t, "6", payload["cached"])
+	output := res.Steps["renderVariables"].Output.(map[string]interface{})
+	assert.Equal(t, "4", output["truc"])
+	assert.Equal(t, "5", output["bidule"])
+	assert.Equal(t, "Hello World!", output["templated"])
+	assert.Equal(t, "6", output["cached"])
+	output = res.Steps["renderVariablesWithCache"].Output.(map[string]interface{})
+	assert.Equal(t, "6", output["cached"])
 }
 
 const (
@@ -578,11 +578,11 @@ func TestJSONTemplating(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, resolution.StateDone, res.State)
 
-	payload := res.Steps["stepOne"].Output.(map[string]interface{})
-	assert.Equal(t, multilineString, payload["raw-multiline"])
-	assert.Equal(t, singleString, payload["raw-single"])
+	output := res.Steps["stepOne"].Output.(map[string]interface{})
+	assert.Equal(t, multilineString, output["raw-multiline"])
+	assert.Equal(t, singleString, output["raw-single"])
 
-	jsonBody := payload["my-json-body"].(string)
+	jsonBody := output["my-json-body"].(string)
 	body := map[string]interface{}{}
 	err = json.Unmarshal([]byte(jsonBody), &body)
 	assert.Nil(t, err)
@@ -598,8 +598,8 @@ func TestJSONNumberTemplating(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, resolution.StateDone, res.State)
 
-	payload := res.Steps["loopStep"].Children
-	child := payload[0].(map[string]interface{})
+	output := res.Steps["loopStep"].Children
+	child := output[0].(map[string]interface{})
 	assert.Equal(t, "/id/1619464078", child[values.OutputKey].(string))
 }
 
@@ -698,9 +698,9 @@ func TestScriptPlugin(t *testing.T) {
 	assert.NotNil(t, res)
 	assert.Nil(t, err)
 
-	payload := make(map[string]interface{})
-	payload["dumb_string"] = fmt.Sprintf("Hello %s!", argv)
-	payload["random_object"] = map[string]interface{}{"foo": "bar"}
+	output := make(map[string]interface{})
+	output["dumb_string"] = fmt.Sprintf("Hello %s!", argv)
+	output["random_object"] = map[string]interface{}{"foo": "bar"}
 
 	metadata := map[string]interface{}{
 		"exit_code":      "0",
@@ -714,7 +714,7 @@ func TestScriptPlugin(t *testing.T) {
 	metadataOutput := res.Steps["stepOne"].Metadata.(map[string]interface{})
 	metadataOutput["execution_time"] = ""
 
-	assert.Equal(t, payload, res.Steps["stepOne"].Payload)
+	assert.Equal(t, output, res.Steps["stepOne"].Output)
 	assert.Equal(t, metadata, metadataOutput)
 }
 

--- a/engine/step/step.go
+++ b/engine/step/step.go
@@ -78,7 +78,6 @@ type Step struct {
 	// result
 	Schema         json.RawMessage         `json:"json_schema,omitempty"`
 	ResultValidate jsonschema.ValidateFunc `json:"-"`
-	Payload        interface{}             `json:"payload,omitempty"` // deprecated, kept for UI backwards compatibility
 	Output         interface{}             `json:"output,omitempty"`
 	Metadata       interface{}             `json:"metadata,omitempty"`
 	Children       []interface{}           `json:"children,omitempty"`
@@ -273,7 +272,6 @@ func Run(st *Step, baseConfig map[string]json.RawMessage, values *values.Values,
 				}
 				st.Output = baseOutput
 			}
-			st.Payload = st.Output // FIXME deprecate
 			if err != nil {
 				if errors.IsBadRequest(err) {
 					st.State = StateClientError

--- a/models/resolution/resolution.go
+++ b/models/resolution/resolution.go
@@ -456,7 +456,6 @@ func (r *Resolution) ExtendRunMax(i int) {
 // -> renders a simplified view of a resolution
 func (r *Resolution) ClearOutputs() {
 	for _, s := range r.Steps {
-		s.Payload = nil // FIXME deprecate
 		s.Output = nil
 		s.Metadata = nil
 		s.Children = nil
@@ -470,11 +469,6 @@ func (r *Resolution) ClearOutputs() {
 func (r *Resolution) setSteps(st map[string]*step.Step) {
 	r.Steps = st
 	for name, s := range r.Steps {
-		// for legacy resolutions, value is found in "payload"
-		// -> copy to "output"
-		if s.Output == nil && s.Payload != nil { // FIXME deprecate
-			s.Output = s.Payload
-		}
 		r.Values.SetOutput(name, s.Output)
 		r.Values.SetMetadata(name, s.Metadata)
 		r.Values.SetChildren(name, s.Children)

--- a/pkg/plugins/builtin/echo/echo.go
+++ b/pkg/plugins/builtin/echo/echo.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ovh/utask/pkg/plugins/taskplugin"
 )
 
-// the echo plugin is used to "manually" build result payloads
+// the echo plugin is used to "manually" build result outputs
 // allowing to aggregate several results in a consolidated structure
 var (
 	Plugin = taskplugin.New("echo", "0.1", exec,

--- a/pkg/plugins/builtin/script/README.md
+++ b/pkg/plugins/builtin/script/README.md
@@ -54,15 +54,15 @@ action:
 
 ## Note
 
-The plugin returns two objects, the `Payload` who is the last returned line of your script as json:
+The plugin returns two objects, `output` and `metadata`.
+
+`output` depends on the `output_mode` configuration. It is read from the stdout of the script, either on the last line (`output_mode` set to `manual-lastline`) or between given delimiters (`output_mode` set to `manual-delimiters`, delimiters defined in `output_manual_delimiters`).
 
 ```json
 {"dumb_string":"Hello world!","random_object":{"foo":"bar"}}
 ```
 
-*Your JSON must be printed on last line*
-
-The `Metadata` to fetch informations about plugin execution:
+`metadata` contains information about the script execution:
 
 ```js
 {

--- a/pkg/plugins/builtin/script/script.go
+++ b/pkg/plugins/builtin/script/script.go
@@ -170,20 +170,20 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 		errorMetadataKey:         metaError,
 	}
 
-	payload := make(map[string]interface{})
+	output := make(map[string]interface{})
 
 	if resultLine, err := scriptutil.ParseOutput(outStr, cfg.OutputMode, cfg.OutputManualDelimiters); err != nil {
 		return nil, metadata, err
 	} else if resultLine != "" {
-		err = json.Unmarshal([]byte(resultLine), &payload)
+		err = json.Unmarshal([]byte(resultLine), &output)
 		if err != nil && exitCode == 0 {
 			return nil, metadata, err
 		}
 	}
 
 	if exitCode != 0 {
-		return payload, metadata, scriptutil.FormatErrorExitCode(exitCode, cfg.ExitCodesUnrecoverable, err)
+		return output, metadata, scriptutil.FormatErrorExitCode(exitCode, cfg.ExitCodesUnrecoverable, err)
 	}
 
-	return payload, metadata, nil
+	return output, metadata, nil
 }

--- a/pkg/plugins/builtin/ssh/README.md
+++ b/pkg/plugins/builtin/ssh/README.md
@@ -15,7 +15,7 @@ The step will be considered successful if the script returns exit code 0, otherw
 | `output_mode` | indicates how to retrieve the output values ; valid values are: `auto-result` (default), `disabled`, `manual-delimiters`, `manual-lastline`
 | `result` | an object to extract the values of variables from the machine's shell (only used when `output_mode` is configured to `auto-result`)
 | `output_manual_delimiters` | array of 2 strings ; look for a JSON formatted string in the script output between specific delimiters (only used when `output_mode` is configured to `manual-delimiters`)
-| `ssh_key` | private ssh key, preferrably retrieved from {{.config}}
+| `ssh_key` | private ssh key, preferably retrieved from {{.config}}
 | `ssh_key_passphrase` | passphrase for the key, if any
 | `exit_codes_unrecoverable` | a list of non-zero exit codes (1, 2, 3, ...) or ranges (1-10, ...) which should be considered unrecoverable and halt execution ; these will be returned to the main engine as a `CLIENT_ERROR`
 
@@ -45,7 +45,7 @@ action:
       pid: $PID
       uptime: $SERVICE_UPTIME
     # credentials
-    ssh_key: '{{.config.mySSHKey}}'
+    ssh_key: '{{.config.mySSHKey.privateKey}}'
     # optional delimiters to look for an output -- requires output_mode set to manual-delimiters
     #output_manual_delimiters: ["JSON_START", "JSON_END"]
     exit_codes_unrecoverable:
@@ -56,11 +56,20 @@ action:
 
 ## Requirements
 
-None by default. Ssh credentials should be retrieved from `{{.config.mySSHKey}}` rather than hardcoded on the template.
+None. SSH credentials should be retrieved from e.g. `{{.config.mySSHKey.privateKey}}` rather than hardcoded in the template.
+Example configuration object __mySSHKey__ (yaml):
+```
+privateKey: |-
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  ...
+  -----END OPENSSH PRIVATE KEY-----
+```
 
 ## Note
 
-The plugin returns two objects, the `Payload` of the execution as defined in the result field of configuration:
+The plugin returns two objects, `output` and `metadata`.
+`output` depends on the `output_mode` configuration. It is read as formatted JSON from the stdout of the SSH session.
+The default `output_mode` (`auto-result`) injects an escaped `echo` command as the last command in the SSH session, to craft a JSON payload where all the values are interpolated by the shell (e.g. shell variables get replaced). The format of this payload is configured via the `result` configuration. Other modes expect the JSON output on the last line (`manual-lastline`) or between given delimiters (`manual-delimiters`).
 
 ```json
 {
@@ -69,7 +78,7 @@ The plugin returns two objects, the `Payload` of the execution as defined in the
 }
 ```
 
-The `Metadata` to fetch informations about plugin execution:
+`metadata` contains information about plugin execution:
 
 ```json
 {

--- a/pkg/plugins/builtin/ssh/ssh.go
+++ b/pkg/plugins/builtin/ssh/ssh.go
@@ -210,7 +210,7 @@ trap printResultJSON EXIT
 		extraCmd = execStr
 	}
 
-	output, err := session.CombinedOutput(extraCmd)
+	stdoutstderr, err := session.CombinedOutput(extraCmd)
 	if err != nil {
 		exitErr, ok := err.(*ssh.ExitError)
 		if ok {
@@ -222,7 +222,7 @@ trap printResultJSON EXIT
 		}
 	}
 
-	outStr := string(output)
+	outStr := string(stdoutstderr)
 	metadata := map[string]interface{}{
 		"output":      outStr,
 		"exit_code":   fmt.Sprint(exitCode),
@@ -230,20 +230,20 @@ trap printResultJSON EXIT
 		"exit_msg":    exitMessage,
 	}
 
-	payload := make(map[string]interface{})
+	output := make(map[string]interface{})
 
 	if resultLine, err := scriptutil.ParseOutput(outStr, cfg.OutputMode, cfg.OutputManualDelimiters); err != nil {
 		return nil, metadata, err
 	} else if resultLine != "" {
-		err = json.Unmarshal([]byte(resultLine), &payload)
+		err = json.Unmarshal([]byte(resultLine), &output)
 		if err != nil && exitCode == 0 {
 			return nil, metadata, err
 		}
 	}
 
 	if exitCode != 0 {
-		return payload, metadata, scriptutil.FormatErrorExitCode(exitCode, cfg.ExitCodesUnrecoverable, err)
+		return output, metadata, scriptutil.FormatErrorExitCode(exitCode, cfg.ExitCodesUnrecoverable, err)
 	}
 
-	return payload, metadata, nil
+	return output, metadata, nil
 }


### PR DESCRIPTION
step.Payload has been replaced by step.Output for quite a time, now is
the time to remove it completely.