### PR TITLE
Resolution: autorun at creation

### DIFF
--- a/api/handler/resolution.go
+++ b/api/handler/resolution.go
@@ -65,7 +65,7 @@ func CreateResolution(c *gin.Context, in *createResolutionIn) (*resolution.Resol
 		}
 	}
 
-	r, err := resolution.Create(dbp, t, in.ResolverInputs, resUser, false, nil) // TODO accept delay in handler
+	r, err := resolution.Create(dbp, t, in.ResolverInputs, resUser, true, nil) // TODO accept delay in handler
 	if err != nil {
 		dbp.Rollback()
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Thomas Schaffer <thomas.schaffer@corp.ovh.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Behavior fix

* **What is the current behavior?** (You can also link to an open issue here)
When a task isnt "auto-runnable" (e.g. with resolver inputs),  the resolution has to be created by a resolver. Then it doesnt run automatically, it also needs to be run by the resolver.


* **What is the new behavior (if this is a feature change)?**
The resolution is created with a TO_AUTORUN state, so it will be run automatically once created.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
