### PR TITLE
json: removing final '\n' from json.NewEncoder.Encode to mimic json.Marshal behaviour

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,7 +78,17 @@ func JSONMarshal(obj interface{}) ([]byte, error) {
 	enc := json.NewEncoder(b)
 	enc.SetEscapeHTML(false)
 	err := enc.Encode(obj)
-	return b.Bytes(), err
+	if err != nil {
+		return nil, err
+	}
+
+	// json.NewEncoder.Encode adds a final '\n', json.Marshal does not.
+	// Let's keep the default json.Marshal behaviour.
+	res := b.Bytes()
+	if len(res) >= 1 && res[len(res)-1] == '\n' {
+		res = res[:len(res)-1]
+	}
+	return res, nil
 }
 
 // JSONMarshalIndent will JSON encode a given object, without escaping HTML characters and indentation
@@ -88,7 +98,17 @@ func JSONMarshalIndent(obj interface{}, prefix, indent string) ([]byte, error) {
 	enc.SetEscapeHTML(false)
 	enc.SetIndent(prefix, indent)
 	err := enc.Encode(obj)
-	return b.Bytes(), err
+	if err != nil {
+		return nil, err
+	}
+
+	// json.NewEncoder.Encode adds a final '\n', json.Marshal does not.
+	// Let's keep the default json.Marshal behaviour.
+	res := b.Bytes()
+	if len(res) >= 1 && res[len(res)-1] == '\n' {
+		res = res[:len(res)-1]
+	}
+	return res, nil
 }
 
 // ConvertJSONRowToSlice takes a json-formatted array and returns a string slice


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove a useless '\n' after utils.JSONMarshal

* **What is the current behavior?** (You can also link to an open issue here)
A useless '\n' is present, and can cause issue if given to a templating function


* **What is the new behavior (if this is a feature change)?**
Remove a useless '\n' after utils.JSONMarshal


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
