### PR TITLE
Feat: configurable max body bytes for server

### DIFF
--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -143,6 +143,7 @@ var rootCmd = &cobra.Command{
 		server.SetDashboardAPIPathPrefix(cfg.DashboardAPIPathPrefix)
 		server.SetEditorPathPrefix(cfg.EditorPathPrefix)
 		server.SetDashboardSentryDSN(cfg.DashboardSentryDSN)
+		server.SetMaxBodyBytes(cfg.ServerOptions.MaxBodyBytes)
 
 		if utask.FDebug {
 			log.SetLevel(log.DebugLevel)

--- a/utask.go
+++ b/utask.go
@@ -89,9 +89,15 @@ type Cfg struct {
 	DashboardAPIPathPrefix  string                   `json:"dashboard_api_path_prefix"`
 	DashboardSentryDSN      string                   `json:"dashboard_sentry_dsn"`
 	EditorPathPrefix        string                   `json:"editor_path_prefix"`
+	ServerOptions           ServerOpt                `json:"server_options"`
 
 	resourceSemaphores map[string]*semaphore.Weighted
 	executionSemaphore *semaphore.Weighted
+}
+
+// ServerOpt holds the configuration for the http server
+type ServerOpt struct {
+	MaxBodyBytes int64 `json:"max_body_bytes"`
 }
 
 // NotifyBackend holds configuration for instantiating a notify client


### PR DESCRIPTION
Signed-off-by: Thomas Schaffer <thomas.schaffer@corp.ovh.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature for the API server


* **What is the current behavior?** (You can also link to an open issue here)
The server only reads up to 256KB to protect itself.


* **What is the new behavior (if this is a feature change)?**
This value is configurable, with lower/upper boundaries: 1KB < x < 10MB


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
