### PR TITLE
sql: Resolutions are now deleted when deleting associated task

### DIFF
--- a/sql/migrations/004_resolution_constraints.sql
+++ b/sql/migrations/004_resolution_constraints.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+
+-- Add a missing 'ON DELETE CASCADE' on resolution->task FOREIGN KEY
+ALTER TABLE resolution DROP CONSTRAINT resolution_id_task_fkey, ADD CONSTRAINT resolution_id_task_fkey FOREIGN KEY (id_task) REFERENCES task(id) ON DELETE CASCADE;
+
+-- +migrate Down
+
+ALTER TABLE resolution DROP CONSTRAINT resolution_id_task_fkey, ADD CONSTRAINT resolution_id_task_fkey FOREIGN KEY (id_task) REFERENCES task(id);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -79,7 +79,7 @@ CREATE INDEX ON "task_comment"(id_task);
 CREATE TABLE "resolution" (
     id BIGSERIAL PRIMARY KEY,
     public_id UUID UNIQUE NOT NULL,
-    id_task BIGINT UNIQUE NOT NULL REFERENCES "task"(id),
+    id_task BIGINT UNIQUE NOT NULL REFERENCES "task"(id) ON DELETE CASCADE,
     resolver_username TEXT,
     state TEXT NOT NULL,
     instance_id BIGINT,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Resolutions are now deleted when deleting associated task


* **What is the current behavior?** (You can also link to an open issue here)
Resolution is not deleted, triggering a constraint error on the API/UI


* **What is the new behavior (if this is a feature change)?**
Resolution deleted at the same time than task.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
