### PR TITLE
feat: add IN and NOTIN to step condition operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,14 @@ A user can be allowed to resolve a task in three ways:
 - `.iterator.foo`: field `foo` from the iterator in a loop (see `foreach` steps below)
 
 The following templating functions are available:
-|Name|Description|Reference
-|---|---|---
-|**`Golang`** | Builtin functions from Golang text template  | [Doc](https://golang.org/pkg/text/template/#hdr-Actions)
-|**`Sprig`** | Extended set of functions from the Sprig project  | [Doc](https://masterminds.github.io/sprig/)
-|**`field`** | Equivalent to the dot notation, for entries with forbidden characters | ``{{field `config` `foo.bar`}}``
-|**`eval`** | Evaluates the value of a template variable | ``{{eval `var1`}}``
-|**`evalCache`** | Evaluates the value of a template variable, and cache for future usage (to avoid further computation) | ``{{evalCache `var1`}}``
+
+| Name            | Description                                                                                           | Reference                                                |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **`Golang`**    | Builtin functions from Golang text template                                                           | [Doc](https://golang.org/pkg/text/template/#hdr-Actions) |
+| **`Sprig`**     | Extended set of functions from the Sprig project                                                      | [Doc](https://masterminds.github.io/sprig/)              |
+| **`field`**     | Equivalent to the dot notation, for entries with forbidden characters                                 | ``{{field `config` `foo.bar`}}``                         |
+| **`eval`**      | Evaluates the value of a template variable                                                            | ``{{eval `var1`}}``                                      |
+| **`evalCache`** | Evaluates the value of a template variable, and cache for future usage (to avoid further computation) | ``{{evalCache `var1`}}``                                 |
 
 ### Basic properties
 
@@ -301,6 +302,21 @@ steps:
           {"user_id":"{{.input.id}}"}
 ```
 
+#### Condition Operators
+
+A condition can use one of the following operators:
+- `EQ`: equal
+- `NE`: not equal
+- `GT`: greater than
+- `LT`: less than
+- `GE`: greater or equal
+- `LE`: less than or equal
+- `REGEXP`: match a regexp
+- `IN`: found in a list of values
+- `NOTIN`: not found in a list of values
+
+Note that the operators `IN` and `NOTIN` expect a list of acceptable values in the field `value`, instead of a single one. You can specify the separator character to use to split the values of the list using the field `list_separator` (default: `,`). Each value of the list will be trimmed of its leading and trailing white spaces before comparison.
+
 #### Basic Step Properties
 
 - `name`: a unique identifier
@@ -406,17 +422,17 @@ Will render the following output, a combination of the action's raw output and t
 
 Browse [builtin actions](./pkg/plugins/builtin)
 
-|Plugin name|Description|Documentation
-|---|---|---
-|**`echo`** | Print out a pre-determined result | [Access plugin doc](./pkg/plugins/builtin/echo/README.md)
-|**`http`** | Make an http request | [Access plugin doc](./pkg/plugins/builtin/http/README.md)
-|**`subtask`** | Spawn a new task on µTask | [Access plugin doc](./pkg/plugins/builtin/subtask/README.md)
-|**`notify`**  | Dispatch a notification over a registered channel | [Access plugin doc](./pkg/plugins/builtin/notify/README.md)
-|**`apiovh`**  | Make a signed call on OVH's public API (requires credentials retrieved from configstore, containing the fields `endpoint`, `appKey`, `appSecret`, `consumerKey`, more info [here](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/)) | [Access plugin doc](./pkg/plugins/builtin/apiovh/README.md)
-|**`ssh`**     | Connect to a remote system and run commands on it | [Access plugin doc](./pkg/plugins/builtin/ssh/README.md)
-|**`email`**   | Send an email | [Access plugin doc](./pkg/plugins/builtin/email/README.md)
-|**`ping`**    | Send a ping to an hostname *Warn: This plugin will keep running until the count is done* | [Access plugin doc](./pkg/plugins/builtin/ping/README.md)
-|**`script`**    | Execute a script under `scripts` folder | [Access plugin doc](./pkg/plugins/builtin/script/README.md)
+| Plugin name   | Description                                                                                                                                                                                                                                       | Documentation                                                |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **`echo`**    | Print out a pre-determined result                                                                                                                                                                                                                 | [Access plugin doc](./pkg/plugins/builtin/echo/README.md)    |
+| **`http`**    | Make an http request                                                                                                                                                                                                                              | [Access plugin doc](./pkg/plugins/builtin/http/README.md)    |
+| **`subtask`** | Spawn a new task on µTask                                                                                                                                                                                                                         | [Access plugin doc](./pkg/plugins/builtin/subtask/README.md) |
+| **`notify`**  | Dispatch a notification over a registered channel                                                                                                                                                                                                 | [Access plugin doc](./pkg/plugins/builtin/notify/README.md)  |
+| **`apiovh`**  | Make a signed call on OVH's public API (requires credentials retrieved from configstore, containing the fields `endpoint`, `appKey`, `appSecret`, `consumerKey`, more info [here](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/)) | [Access plugin doc](./pkg/plugins/builtin/apiovh/README.md)  |
+| **`ssh`**     | Connect to a remote system and run commands on it                                                                                                                                                                                                 | [Access plugin doc](./pkg/plugins/builtin/ssh/README.md)     |
+| **`email`**   | Send an email                                                                                                                                                                                                                                     | [Access plugin doc](./pkg/plugins/builtin/email/README.md)   |
+| **`ping`**    | Send a ping to an hostname *Warn: This plugin will keep running until the count is done*                                                                                                                                                          | [Access plugin doc](./pkg/plugins/builtin/ping/README.md)    |
+| **`script`**  | Execute a script under `scripts` folder                                                                                                                                                                                                           | [Access plugin doc](./pkg/plugins/builtin/script/README.md)  |
 
 #### Dependencies <a name="dependencies"></a>
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -377,6 +377,7 @@ func TestStepConditionStates(t *testing.T) {
 	assert.Equal(t, "OK", res.Steps["stepFour"].Error)
 
 	assert.Equal(t, "PRUNE", res.Steps["stepFive"].State)
+	assert.Equal(t, "LIST_NOMATCH", res.Steps["stepSix"].State)
 }
 
 func TestResolutionStateCrashed(t *testing.T) {

--- a/engine/templates_tests/stepCondition.yaml
+++ b/engine/templates_tests/stepCondition.yaml
@@ -129,7 +129,7 @@ steps:
               message: List contains matching value
             - type: check
               if:
-                  - expected: {{.step.this.state}}
+                  - expected: '{{.step.this.state}}'
                     operator: EQ
                     value: 'LIST_MATCH'
                   - expected: baz

--- a/engine/templates_tests/stepCondition.yaml
+++ b/engine/templates_tests/stepCondition.yaml
@@ -108,3 +108,34 @@ steps:
               then:
                   this: OK
               message: OK
+    stepSix:
+        dependencies: [stepThree:ANY]
+        description: a check against a list of acceptable values
+        custom_states: [LIST_MATCH,LIST_NOMATCH]
+        action:
+            type: echo
+            configuration:
+                output:
+                    items: 'foo,bar'
+        conditions:
+            - type: check
+              if:
+                  - expected: foo
+                    operator: IN
+                    value: '{{.step.this.output.items}}'
+                    list_separator: ","
+              then:
+                  this: LIST_MATCH
+              message: List contains matching value
+            - type: check
+              if:
+                  - expected: {{.step.this.state}}
+                    operator: EQ
+                    value: 'LIST_MATCH'
+                  - expected: baz
+                    operator: NOTIN
+                    value: '{{.step.this.output.items}}'
+                    list_separator: ","
+              then:
+                  this: LIST_NOMATCH
+              message: List doesn't contains matching value

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -10,18 +10,16 @@
             "title": "A µTask template step",
             "default": {},
             "additionalProperties": false,
-            "examples": [
-                {
-                    "description": "Get UTC time",
-                    "action": {
-                        "type": "http",
-                        "configuration": {
-                            "method": "GET",
-                            "url": "http://worldclockapi.com/api/json/utc/now"
-                        }
+            "examples": [{
+                "description": "Get UTC time",
+                "action": {
+                    "type": "http",
+                    "configuration": {
+                        "method": "GET",
+                        "url": "http://worldclockapi.com/api/json/utc/now"
                     }
                 }
-            ],
+            }],
             "required": [
                 "description",
                 "action"
@@ -81,8 +79,7 @@
             }
         },
         "Action": {
-            "oneOf": [
-                {
+            "oneOf": [{
                     "$ref": "#/definitions/ActionHTTP"
                 },
                 {
@@ -668,7 +665,9 @@
                                     "LT",
                                     "GE",
                                     "LE",
-                                    "REGEXP"
+                                    "REGEXP",
+                                    "IN",
+                                    "NOTIN"
                                 ]
                             },
                             "expected": {
@@ -695,18 +694,16 @@
         "Input": {
             "type": "object",
             "additionalProperties": false,
-            "examples": [
-                {
-                    "name": "language",
-                    "default": "english",
-                    "optional": true,
-                    "description": "The language in which you wish to greet the world",
-                    "legal_values": [
-                        "english",
-                        "spanish"
-                    ]
-                }
-            ],
+            "examples": [{
+                "name": "language",
+                "default": "english",
+                "optional": true,
+                "description": "The language in which you wish to greet the world",
+                "legal_values": [
+                    "english",
+                    "spanish"
+                ]
+            }],
             "required": [
                 "name",
                 "description"
@@ -777,8 +774,7 @@
         "Variable": {
             "type": "object",
             "additionalProperties": false,
-            "examples": [
-                {
+            "examples": [{
                     "name": "english-message",
                     "value": "Hello World!"
                 },
@@ -865,12 +861,10 @@
             "type": "object",
             "description": "Describes the object format that will be saved as task result",
             "default": {},
-            "examples": [
-                {
-                    "echo_message": "{{.step.sayHello.output.message}}",
-                    "echo_when": "{{.step.sayHello.output.when}}"
-                }
-            ]
+            "examples": [{
+                "echo_message": "{{.step.sayHello.output.message}}",
+                "echo_when": "{{.step.sayHello.output.when}}"
+            }]
         },
         "allowed_resolver_usernames": {
             "type": "array",


### PR DESCRIPTION
These operators allows to check that a value is present or not
in a list of values. The allowed/disabled values are represented
as a comma-separated string.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

* **What is the current behavior?** (You can also link to an open issue here)

A value cannot be checked against a list of potential candidates in a step condition.

* **What is the new behavior (if this is a feature change)?**

This permits to assert that a value is present or not in a list of acceptable values.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
