### PR TITLE
fix: log: DatabaseConfig log message was invalid 

### DIFF
--- a/db/init.go
+++ b/db/init.go
@@ -84,7 +84,7 @@ func Init(store *configstore.Store) error {
 		cfg.ConnMaxLifetime = intPtr(defaultConnMaxLifetime)
 	}
 	logrus.Infof("[DatabaseConfig] Using %d max open connections, %d max idle connections, %d seconds timeout",
-		cfg.MaxOpenConns, cfg.MaxIdleConns, cfg.ConnMaxLifetime,
+		*cfg.MaxOpenConns, *cfg.MaxIdleConns, *cfg.ConnMaxLifetime,
 	)
 	db.SetMaxOpenConns(*cfg.MaxOpenConns)
 	db.SetMaxIdleConns(*cfg.MaxIdleConns)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixing a display bug in logs


* **What is the current behavior?** (You can also link to an open issue here)
`[DatabaseConfig] Using 824636286104 max open connections, 824636286144 max idle connections, 824636286152 seconds timeout`


* **What is the new behavior (if this is a feature change)?**
`[DatabaseConfig] Using 20 max open connections, 20 max idle connections, 5 seconds timeout`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
