### PR TITLE
fix: ssh: Closing net.Conn after SSH finished its execution

### DIFF
--- a/pkg/plugins/builtin/ssh/ssh.go
+++ b/pkg/plugins/builtin/ssh/ssh.go
@@ -157,6 +157,7 @@ func execssh(stepName string, i interface{}, ctx interface{}) (interface{}, inte
 	if err != nil {
 		return nil, nil, err
 	}
+	defer client.Close()
 
 	session, err := client.NewSession()
 	if err != nil {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Closing net.Conn used by ssh plugin, to release connection on remote host


* **What is the current behavior?** (You can also link to an open issue here)
Not closing the connection


* **What is the new behavior (if this is a feature change)?**
Closing the connection


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
