### PR TITLE
fix: engine: step with invalid JSON output are considered as FATAL_ERROR

### DIFF
--- a/pkg/plugins/builtin/ping/ping.go
+++ b/pkg/plugins/builtin/ping/ping.go
@@ -3,6 +3,7 @@ package ping
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -85,6 +86,10 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 	pinger.Run()
 
 	so := pinger.Statistics()
+	// ping library can return some invalid float64 values, let's prevent this.
+	if math.IsNaN(so.PacketLoss) || math.IsInf(so.PacketLoss, 0) {
+		so.PacketLoss = float64(0)
+	}
 
 	return &pingStats{
 		PacketsRecv: so.PacketsRecv,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix an issue while step output is not a valid JSON object.


* **What is the current behavior?** (You can also link to an open issue here)
When a plugin returns an invalid output, which can't be marshaled as
JSON, step was stucked in a retry loop to be committed.


* **What is the new behavior (if this is a feature change)?**
Now, step will be set in FATAL_ERROR state, to be investigated by a human operator.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
