### PR TITLE
Add POST resolution reinstitute endpoint

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -363,45 +363,6 @@ func TestResolution(t *testing.T) {
 		tester := iffy.NewTester(t, hdl)
 		defer tester.Run()
 
-		var echoWithConditionTemplate = func() tasktemplate.TaskTemplate {
-			return tasktemplate.TaskTemplate{
-				Name:        "echo-with-condition-template",
-				Description: "echo with condition template",
-				TitleFormat: "this task does echo based on the resolver input",
-				ResolverInputs: []input.Input{
-					{
-						Name: "callback_status",
-					},
-				},
-				Steps: map[string]*step.Step{
-					"step": {
-						Action: step.Executor{
-							Type: "echo",
-							Configuration: json.RawMessage(`{
-								"output": {"foo":"bar"}
-							}`),
-						},
-						Conditions: []*step.Condition{
-							&step.Condition{
-								Type: "check",
-								If: []*step.Assert{
-									&step.Assert{
-										Value:    "{{.resolver_input.callback_status}}",
-										Operator: "NE",
-										Expected: "done",
-									},
-								},
-								Then: map[string]string{
-									"this": "TO_RETRY",
-								},
-								Message: "waiting for callback",
-							},
-						},
-					},
-				},
-			}
-		}
-
 		dbp, err := zesty.NewDBProvider(utask.DBName)
 		if err != nil {
 			t.Fatal(err)
@@ -695,6 +656,45 @@ func dummyTemplate() tasktemplate.TaskTemplate {
 					Configuration: json.RawMessage(`{
 						"output": {"foo":"bar"}
 					}`),
+				},
+			},
+		},
+	}
+}
+
+func echoWithConditionTemplate() tasktemplate.TaskTemplate {
+	return tasktemplate.TaskTemplate{
+		Name:        "echo-with-condition-template",
+		Description: "echo with condition template",
+		TitleFormat: "this task does echo based on the resolver input",
+		ResolverInputs: []input.Input{
+			{
+				Name: "callback_status",
+			},
+		},
+		Steps: map[string]*step.Step{
+			"step": {
+				Action: step.Executor{
+					Type: "echo",
+					Configuration: json.RawMessage(`{
+								"output": {"foo":"bar"}
+							}`),
+				},
+				Conditions: []*step.Condition{
+					&step.Condition{
+						Type: "check",
+						If: []*step.Assert{
+							&step.Assert{
+								Value:    "{{.resolver_input.callback_status}}",
+								Operator: "NE",
+								Expected: "done",
+							},
+						},
+						Then: map[string]string{
+							"this": "TO_RETRY",
+						},
+						Message: "waiting for callback",
+					},
 				},
 			},
 		},

--- a/api/handler/resolution.go
+++ b/api/handler/resolution.go
@@ -459,3 +459,31 @@ func PauseResolution(c *gin.Context, in *pauseResolutionIn) error {
 
 	return nil
 }
+
+type reinstituteResolutionIn struct {
+	PublicID       string                 `path:"id, required"`
+	Force          bool                   `query:"force"`
+	Steps          map[string]*step.Step  `json:"steps"` // persisted in encrypted blob
+	ResolverInputs map[string]interface{} `json:"resolver_inputs"`
+}
+
+func ReinstituteResolution(c *gin.Context, in *reinstituteResolutionIn) error {
+	if err := PauseResolution(c, &pauseResolutionIn{
+		PublicID: in.PublicID,
+		Force:    in.Force,
+	}); err != nil {
+		return err
+	}
+
+	if err := UpdateResolution(c, &updateResolutionIn{
+		PublicID:       in.PublicID,
+		Steps:          in.Steps,
+		ResolverInputs: in.ResolverInputs,
+	}); err != nil {
+		return err
+	}
+
+	return RunResolution(c, &runResolutionIn{
+		PublicID: in.PublicID,
+	})
+}

--- a/api/server.go
+++ b/api/server.go
@@ -330,6 +330,12 @@ func (s *Server) build(ctx context.Context) {
 					},
 					maintenanceMode,
 					tonic.Handler(handler.CancelResolution, 204))
+				resolutionRoutes.POST("/resolution/:id/reinstitute",
+					[]fizz.OperationOption{
+						fizz.Summary("Reinstitute a task"),
+						fizz.Description("This is a combination of pause + update + run."),
+					},
+					tonic.Handler(handler.ReinstituteResolution, 204))
 
 				//	resolutionRoutes.POST("/resolution/:id/rollback",
 				//		[]fizz.OperationOption{

--- a/models/task/task.go
+++ b/models/task/task.go
@@ -566,6 +566,9 @@ func (t *Task) ExportTaskInfos(values *values.Values) {
 	}
 	m["last_activity"] = t.LastActivity
 	m["region"] = utask.FRegion
+	if t.Resolution != nil {
+		m["resolution_id"] = t.Resolution
+	}
 
 	values.SetTaskInfos(m)
 }

--- a/models/tasktemplate/validate.go
+++ b/models/tasktemplate/validate.go
@@ -31,7 +31,7 @@ func validTemplate(template string, inputs, resolverInputs []string, steps map[s
 	}
 
 	stepNames := stepNames(steps)
-	taskInfoKeys := []string{"resolver_username", "created", "requester_username", "task_id", "region"}
+	taskInfoKeys := []string{"resolver_username", "created", "requester_username", "task_id", "region", "resolution_id"}
 	for _, m := range matches {
 		parts := strings.Split(m[1], ".")
 		if len(parts) >= 3 {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds a feature so that we can combine `pause`, `update`, and `run` into one api: `reinstitute`. This is useful for the webhook callback action or workflow. 

Example of usage of this endpoint with resolver input and condition:
```yaml

resolver_inputs:                       
- name: callback_state       
  description: callback state
  default: pending                     

steps:
  send_http:
    action:                                                                     
      type: http                                                                
      configuration:                                                            
        url: xxx
        method: xxx                                                          
        body: xxx
        # This example is using headers, you can also use path parameter or body.
        # Depends on the remote callback pattern, we just need to tell them how to send the callback to utask
        # Notice that we need .task.resolution_id, which is also added in this PR
        # Remote server is likely to send request like
        #     curl -H 'Content-Type: application/json' -d '{"resolver_input": {"callback_state": "done"}}' 'http://utask:8081/resolution/{{.task.resolution_id}}/reinstitute'
        headers:                                                                
        - name: x-callback-url                                                  
          value: 'http://utask:8081/resolution/{{.task.resolution_id}}/reinstitute'

  wait_for_callback:
    action:                                                            
      type: echo                                                       
      configuration:                                                   
        output:                                                        
          state: '{{.resolver_input.callback_state}}'        
    conditions:                                                        
    - type: check                                                      
      if:                                                              
      - value: '{{.resolver_input.callback_state}}'          
        operator: NE                                                   
        expected: 'done'                                               
      then:                                                            
        this: TO_RETRY                                                 
      message: 'pending and waiting for callback'                                  
```



* **What is the current behavior?** (You can also link to an open issue here)
- Currently we need to send 3 APIs
- Currently resolution_id is not available in the values


* **What is the new behavior (if this is a feature change)?**
- Added new `/resolution/:resolution_id/reinstitute` api
- Added `resolution_id` in the templating value context


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. See unit tests.


* **Other information**:
