### PR TITLE
feature: add resolution id as task value

### DIFF
--- a/models/task/task.go
+++ b/models/task/task.go
@@ -566,6 +566,9 @@ func (t *Task) ExportTaskInfos(values *values.Values) {
 	}
 	m["last_activity"] = t.LastActivity
 	m["region"] = utask.FRegion
+	if t.Resolution != nil {
+		m["resolution_id"] = t.Resolution
+	}
 
 	values.SetTaskInfos(m)
 }

--- a/models/tasktemplate/validate.go
+++ b/models/tasktemplate/validate.go
@@ -31,7 +31,7 @@ func validTemplate(template string, inputs, resolverInputs []string, steps map[s
 	}
 
 	stepNames := stepNames(steps)
-	taskInfoKeys := []string{"resolver_username", "created", "requester_username", "task_id", "region"}
+	taskInfoKeys := []string{"resolver_username", "created", "requester_username", "task_id", "region", "resolution_id"}
 	for _, m := range matches {
 		parts := strings.Split(m[1], ".")
 		if len(parts) >= 3 {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add `resolution_id` as one of the task values. It really helps to leverage `resolution_id` for some customized init plugins or actions.


* **What is the current behavior?** (You can also link to an open issue here)
resolution_id was not in task values.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
