### PR TITLE
task: adding tasktemplate variables to Go templating for new task creation (to be used in task title format)

### DIFF
--- a/models/task/task.go
+++ b/models/task/task.go
@@ -136,6 +136,7 @@ func Create(dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, reqUsername str
 	// title can be computed if input values are valid
 	v := values.NewValues()
 	v.SetInput(input)
+	v.SetVariables(tt.Variables)
 	t.ExportTaskInfos(v) // make task-specific info available for title
 	title, err := v.Apply(tt.TitleFormat, nil, "")
 	if err != nil {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature/bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Task title format can't be templated with variables that contains .input variables.


* **What is the new behavior (if this is a feature change)?**
tasktemplate Variables are now injected into uTask templating at task creation 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
