### PR TITLE
templates: text/template values should include digits

### DIFF
--- a/models/task/task.go
+++ b/models/task/task.go
@@ -383,6 +383,7 @@ func (t *Task) Update(dbp zesty.DBProvider, skipValidation, recordLastActivity b
 		// re-template task title in case inputs were updated
 		v := values.NewValues()
 		v.SetInput(t.Input)
+		v.SetVariables(tt.Variables)
 		t.ExportTaskInfos(v)
 		title, err := v.Apply(tt.TitleFormat, nil, "")
 		if err != nil {

--- a/models/tasktemplate/validate.go
+++ b/models/tasktemplate/validate.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	tmplRegex = regexp.MustCompile(`{{[^}\.]*(\.[A-Za-z_\.]+)[^{]*}}`)
+	tmplRegex = regexp.MustCompile(`{{[^}\.]*(\.[A-Za-z0-9_\.]+)[^{]*}}`)
 )
 
 func validTemplate(template string, inputs, resolverInputs []string, steps map[string]*step.Step) error {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Variable with `{{.input.foo1}}` would not be validated because utask will be looking for `foo` instead of `foo1` in inputs.


* **What is the new behavior (if this is a feature change)?**
Looking for `foo1`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
No