### PR TITLE
feat: add custom middlewares for init plugins

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -70,6 +70,7 @@ func TestMain(m *testing.M) {
 
 	srv := api.NewServer()
 	srv.WithAuth(dumbIdentityProvider)
+	srv.WithCustomMiddlewares(dummyCustomMiddleware)
 	srv.SetDashboardPathPrefix("")
 	srv.SetDashboardAPIPathPrefix("")
 	srv.SetDashboardSentryDSN("")
@@ -85,6 +86,10 @@ func TestMain(m *testing.M) {
 	hdl = srv.Handler(ctx)
 
 	os.Exit(m.Run())
+}
+
+func dummyCustomMiddleware(c *gin.Context) {
+	c.Next()
 }
 
 func dumbIdentityProvider(r *http.Request) (string, error) {

--- a/api/server.go
+++ b/api/server.go
@@ -58,7 +58,7 @@ func (s *Server) WithAuth(authProvider func(*http.Request) (string, error)) {
 // WithCustomMiddlewares sets an array of customized gin middlewares.
 // It helps for init plugins to include these customized middlewares in the api server
 func (s *Server) WithCustomMiddlewares(customMiddlewares ...gin.HandlerFunc) {
-	s.customMiddlewares = customMiddlewares
+	s.customMiddlewares = append(s.customerMiddlewares, customMiddlewares...)
 }
 
 // SetDashboardPathPrefix configures the custom path prefix for dashboard static files hosting.

--- a/api/server.go
+++ b/api/server.go
@@ -58,7 +58,7 @@ func (s *Server) WithAuth(authProvider func(*http.Request) (string, error)) {
 // WithCustomMiddlewares sets an array of customized gin middlewares.
 // It helps for init plugins to include these customized middlewares in the api server
 func (s *Server) WithCustomMiddlewares(customMiddlewares ...gin.HandlerFunc) {
-	s.customMiddlewares = append(s.customerMiddlewares, customMiddlewares...)
+	s.customMiddlewares = append(s.customMiddlewares, customMiddlewares...)
 }
 
 // SetDashboardPathPrefix configures the custom path prefix for dashboard static files hosting.

--- a/api/server.go
+++ b/api/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	dashboardSentryDSN     string
 	editorPathPrefix       string
 	maxBodyBytes           int64
+	customMiddlewares      []gin.HandlerFunc
 }
 
 // NewServer returns a new Server
@@ -52,6 +53,12 @@ func (s *Server) WithAuth(authProvider func(*http.Request) (string, error)) {
 	if authProvider != nil {
 		s.authMiddleware = authMiddleware(authProvider)
 	}
+}
+
+// WithCustomMiddlewares sets an array of customized gin middlewares.
+// It helps for init plugins to include these customized middlewares in the api server
+func (s *Server) WithCustomMiddlewares(customMiddlewares ...gin.HandlerFunc) {
+	s.customMiddlewares = customMiddlewares
 }
 
 // SetDashboardPathPrefix configures the custom path prefix for dashboard static files hosting.
@@ -178,6 +185,7 @@ func (s *Server) build(ctx context.Context) {
 			},
 		})
 
+		router.Use(s.customMiddlewares...)
 		router.Use(ajaxHeadersMiddleware, errorLogMiddleware)
 
 		tonic.SetErrorHook(jujerr.ErrHook)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A new feature for init plugin to add custom middlewares.

* **What is the current behavior?** (You can also link to an open issue here)
Currently there's no easy way to add custom middlewares.


* **What is the new behavior (if this is a feature change)?**
A new function `WithCustomMiddlewares`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
