### PR TITLE
refactor: plugin email without auth

### DIFF
--- a/pkg/plugins/builtin/email/README.md
+++ b/pkg/plugins/builtin/email/README.md
@@ -4,18 +4,18 @@ This plugin send an email.
 
 ## Configuration
 
-|Fields|Description
-|---|---
-| `smtp_username` | username of SMTP server
-| `smtp_password` | password of SMTP server
-| `smtp_port` | port of SMTP server
-| `smtp_hostname` | hostname of SMTP server
-| `smtp_skip_tls_verif` | Skip or not TLS insecure verify
-| `from_address` | from which email you want to send the message
-| `from_name` | from which name you want to send the message
-| `to` | receiver(s) of your email
-| `subject` | subject of your email
-| `body` | content of your email
+| Fields                | Description                                   |
+| --------------------- | --------------------------------------------- |
+| `smtp_username`       | username of SMTP server                       |
+| `smtp_password`       | password of SMTP server                       |
+| `smtp_port`           | port of SMTP server                           |
+| `smtp_hostname`       | hostname of SMTP server                       |
+| `smtp_skip_tls_verif` | Skip or not TLS insecure verify               |
+| `from_address`        | from which email you want to send the message |
+| `from_name`           | from which name you want to send the message  |
+| `to`                  | receiver(s) of your email                     |
+| `subject`             | subject of your email                         |
+| `body`                | content of your email                         |
 
 ## Example
 
@@ -25,9 +25,9 @@ An action of type `email` requires the following kind of configuration:
 action:
   type: email
   configuration:
-    # mandatory, string
+    # optional, string, leave empty for no auth
     smtp_username: {{.config.smtp.username}}
-    # mandatory, string
+    # optional, string, leave empty for no auth
     smtp_password: {{.config.smtp.password}}
     # mandatory, string as uint
     smtp_port: {{.config.smtp.port}}

--- a/pkg/plugins/builtin/email/email.go
+++ b/pkg/plugins/builtin/email/email.go
@@ -41,14 +41,6 @@ type Config struct {
 func validConfig(config interface{}) error {
 	cfg := config.(*Config)
 
-	if cfg.SMTPUsername == "" {
-		return errors.New("smtp_username is missing")
-	}
-
-	if cfg.SMTPPassword == "" {
-		return errors.New("smtp_password is missing")
-	}
-
 	if cfg.SMTPPort == "" {
 		return errors.New("smtp_port is missing")
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Refactor the `email` plugin to allow using it with SMTP servers that doesn't require authentication.

* **What is the current behavior?** (You can also link to an open issue here)

Configuration fields `smtp_username` and `smtp_password` are mandatory.

* **What is the new behavior (if this is a feature change)?**

The username and password fields are no longer required, and can be left empty. In this case, the `mail.v2` package will simply try to connect to the SMTP server without authentication. See https://github.com/go-mail/mail/blob/v2.3.1/smtp.go#L122

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, current configurations for this plugin will continue to work as expected.
