### PR TITLE
feat: task now includes the tasktemplate resolver_inputs to be displayed directly without requesting the template informations

### DIFF
--- a/models/task/task.go
+++ b/models/task/task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ovh/utask"
 	"github.com/ovh/utask/db/pgjuju"
 	"github.com/ovh/utask/db/sqlgenerator"
+	"github.com/ovh/utask/engine/input"
 	"github.com/ovh/utask/engine/values"
 	"github.com/ovh/utask/models"
 	"github.com/ovh/utask/models/tasktemplate"
@@ -59,6 +60,7 @@ type Task struct {
 	Comments         []*Comment             `json:"comments,omitempty" db:"-"`
 	Batch            *string                `json:"batch,omitempty" db:"batch_public_id"`
 	Errors           []StepError            `json:"errors,omitempty" db:"-"`
+	ResolverInputs   []input.Input          `json:"resolver_inputs,omitempty" db:"resolver_inputs"`
 }
 
 // DBModel is the "strict" representation of a task in DB, as expressed in SQL schema
@@ -577,7 +579,7 @@ func (t *Task) ExportTaskInfos(values *values.Values) {
 
 var (
 	tSelector = sqlgenerator.PGsql.Select(
-		`"task".id, "task".public_id, "task".title, "task".id_template, "task".id_batch, "task".requester_username, "task".watcher_usernames, "task".created, "task".state, "task".tags, "task".steps_done, "task".steps_total, "task".crypt_key, "task".encrypted_input, "task".encrypted_result, "task".last_activity, "task".resolver_usernames, "task_template".name as template_name, "resolution".public_id as resolution_public_id, "resolution".last_start as last_start, "resolution".last_stop as last_stop, "resolution".resolver_username as resolver_username, "batch".public_id as batch_public_id`,
+		`"task".id, "task".public_id, "task".title, "task".id_template, "task".id_batch, "task".requester_username, "task".watcher_usernames, "task".created, "task".state, "task".tags, "task".steps_done, "task".steps_total, "task".crypt_key, "task".encrypted_input, "task".encrypted_result, "task".last_activity, "task".resolver_usernames, "task_template".name as template_name, "task_template".resolver_inputs as resolver_inputs, "resolution".public_id as resolution_public_id, "resolution".last_start as last_start, "resolution".last_stop as last_stop, "resolution".resolver_username as resolver_username, "batch".public_id as batch_public_id`,
 	).From(
 		`"task"`,
 	).Join(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature: add tasktemplate `resolver_input` in the `GET /task/:taskId` to retrieve it without requesting the tasktemplate.
This is needed when the tasktemplate is hidden and will not be listed for regular users. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
