### PR TITLE
fix: task: always return input in GET /task

### DIFF
--- a/models/task/task.go
+++ b/models/task/task.go
@@ -49,7 +49,7 @@ type StepError struct {
 type Task struct {
 	DBModel
 	TemplateName     string                 `json:"template_name" db:"template_name"`
-	Input            map[string]interface{} `json:"input,omitempty" db:"-"`
+	Input            map[string]interface{} `json:"input" db:"-"`
 	Result           map[string]interface{} `json:"result,omitempty" db:"-"`
 	ResultStr        string                 `json:"-" db:"-"`
 	Resolution       *string                `json:"resolution,omitempty" db:"resolution_public_id"`


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When a task have no inputs, we should return the input property, to
provide a stable API for the dashboard UI


* **What is the current behavior?** (You can also link to an open issue here)
Key is missing


* **What is the new behavior (if this is a feature change)?**
Key is present now


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
