### PR TITLE
feat: Update prometheus metrics and add duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ We will list in this document any breaking changes between versions, that requir
 
 ## Breaking changes
 
-### v1.9.0
+### v1.10.0
 #### SQL
 - `005_resolution_creation_timestamp.sql` migration file should be applied while upgrading. It adds a column `created` in the `resolution` table to keep track of the resolution creation timestamp.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ We will list in this document any breaking changes between versions, that requir
 
 ## Breaking changes
 
+### v1.9.0
+#### SQL
+- `005_resolution_creation_timestamp.sql` migration file should be applied while upgrading. It adds a column `created` in the `resolution` table to keep track of the resolution creation timestamp.
+
+#### Prometheus metrics
+- The Prometheus gauges used to record the number of tasks by state haven been moved to a single `GaugeVec` named `utask_task_state`.
+
 ### v1.5.0 (2020-04-09)
 ##### Templating
 - `jsonmarshal` function has been __deleted__. It was obsolete since the `sprig` package used by utask provides many JSON related functions (e.g. `toJson`).

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -14,17 +14,8 @@ import (
 	"github.com/ovh/utask/models/task"
 )
 
-const taskStateMetricPrefix = "utask_task_state_total_"
-
 var (
-	gauges = map[string]prometheus.Gauge{
-		task.StateTODO:      promauto.NewGauge(prometheus.GaugeOpts{Name: taskStateMetricPrefix + task.StateTODO}),
-		task.StateBlocked:   promauto.NewGauge(prometheus.GaugeOpts{Name: taskStateMetricPrefix + task.StateBlocked}),
-		task.StateRunning:   promauto.NewGauge(prometheus.GaugeOpts{Name: taskStateMetricPrefix + task.StateRunning}),
-		task.StateWontfix:   promauto.NewGauge(prometheus.GaugeOpts{Name: taskStateMetricPrefix + task.StateWontfix}),
-		task.StateDone:      promauto.NewGauge(prometheus.GaugeOpts{Name: taskStateMetricPrefix + task.StateDone}),
-		task.StateCancelled: promauto.NewGauge(prometheus.GaugeOpts{Name: taskStateMetricPrefix + task.StateCancelled}),
-	}
+	metrics = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "utask_task_state"}, []string{"status"})
 )
 
 func collectMetrics(ctx context.Context) {
@@ -44,9 +35,7 @@ func collectMetrics(ctx context.Context) {
 					logrus.Warn(err)
 				}
 				for state, count := range stats {
-					if gauge, ok := gauges[state]; ok {
-						gauge.Set(count)
-					}
+					metrics.WithLabelValues(state).Set(count)
 				}
 			case <-ctx.Done():
 				tick.Stop()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -481,6 +481,9 @@ func resolve(dbp zesty.DBProvider, res *resolution.Resolution, t *task.Task, sm 
 		if err := t.SetResult(res.Values); err != nil {
 			debugLogger.Debugf("Engine: resolve() %s loop, task SetResult error: %s", res.PublicID, err)
 		}
+
+		// register task duration statistics
+		task.RegisterTaskTime(t.TemplateName, t.DBModel.Created, res.Created)
 	}
 
 	// further qualify a resolution in error state -> give hints to collectors, change task state if intervention required

--- a/hack/test-docker.sh
+++ b/hack/test-docker.sh
@@ -3,7 +3,7 @@
 export PG_USER="test"
 export PG_PASSWORD="test"
 export PG_PORT="5432"
-export PG_DATABASENAME="postgres"
+export PG_DATABASENAME="test"
 
 PG_DOCKER_ID=$(docker run -v $PWD/sql/schema.sql:/docker-entrypoint-initdb.d/v0001.sql:ro -e POSTGRES_USER=$PG_USER -e POSTGRES_PASSWORD=$PG_PASSWORD -e POSTGRES_DBNAME=$PG_DATABASENAME -d postgres:9.6-alpine)
 

--- a/models/task/stats.go
+++ b/models/task/stats.go
@@ -33,11 +33,11 @@ func RegisterValidationTime(templateName string, taskCreation time.Time) {
 
 // RegisterTaskTime computes the execution duration and the complete duration
 // (from creation to completion) of a task. These metrics are then pushed to Prometheus.
-func RegisterTaskTime(templateName string, tackCreation, resCreation time.Time) {
+func RegisterTaskTime(templateName string, taskCreation, resCreation time.Time) {
 	currentTime := now.Get()
 
 	// Time taken since task creation
-	completeTime := currentTime.Sub(tackCreation).Seconds()
+	completeTime := currentTime.Sub(taskCreation).Seconds()
 	completionTimes.WithLabelValues(templateName).Observe(completeTime)
 
 	// Time taken since resolution was created

--- a/sql/migrations/005_resolution_creation_timestamp.sql
+++ b/sql/migrations/005_resolution_creation_timestamp.sql
@@ -3,7 +3,7 @@
 -- Adds the resolution creation timestamp on resolution table and sets its value to last_start
 ALTER TABLE "resolution" ADD COLUMN "created" TIMESTAMP with time zone;
 UPDATE "resolution" SET created = last_start;
-ALTER TABLE "resolution" ALTER COLUMN "created" SET NOT NULL;
+ALTER TABLE "resolution" ALTER COLUMN "created" SET NOT NULL, ALTER COLUMN "created" SET DEFAULT now();
 
 -- +migrate Down
 

--- a/sql/migrations/005_resolution_creation_timestamp.sql
+++ b/sql/migrations/005_resolution_creation_timestamp.sql
@@ -1,7 +1,9 @@
 -- +migrate Up
 
--- Adds the resolution creation timestamp on resolution table
-ALTER TABLE "resolution" ADD COLUMN "created" TIMESTAMP with time zone DEFAULT now() NOT NULL;
+-- Adds the resolution creation timestamp on resolution table and sets its value to last_start
+ALTER TABLE "resolution" ADD COLUMN "created" TIMESTAMP with time zone;
+UPDATE "resolution" SET created = last_start;
+ALTER TABLE "resolution" ALTER COLUMN "created" SET NOT NULL;
 
 -- +migrate Down
 

--- a/sql/migrations/005_resolution_creation_timestamp.sql
+++ b/sql/migrations/005_resolution_creation_timestamp.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+
+-- Adds the resolution creation timestamp on resolution table
+ALTER TABLE "resolution" ADD COLUMN "created" TIMESTAMP with time zone DEFAULT now() NOT NULL;
+
+-- +migrate Down
+
+ALTER TABLE "resolution" DROP COLUMN "created";

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -83,6 +83,7 @@ CREATE TABLE "resolution" (
     resolver_username TEXT,
     state TEXT NOT NULL,
     instance_id BIGINT,
+    created TIMESTAMP with time zone DEFAULT now() NOT NULL,
     last_start TIMESTAMP with time zone,
     last_stop TIMESTAMP with time zone,
     next_retry TIMESTAMP with time zone,


### PR DESCRIPTION
Signed-off-by: Arthur Amstutz <18141571+amstuta@users.noreply.github.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  - Simplify registration of previously existing statistics to Prometheus
  - Add new statistics: duration between task creation and resolution creation, execution time, and complete time taken between task creation and task completion

* **What is the current behavior?** (You can also link to an open issue here)

The number of tasks by state is register state by state in Prometheus (one Gauge for each state).

* **What is the new behavior (if this is a feature change)?**

A GaugeVec is used to store all the Gauges for the number of tasks by state.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  - Database schema change: the column "created" is added in table "resolution" to register the timestamp when a resolution is created
  - Users that retrieved the number of tasks by state in Prometheus will have to change the way of getting each individual stat.
