### PR TITLE
api: add comments when admins performs manual actions on task or resolution

### DIFF
--- a/pkg/plugins/builtin/subtask/subtask.go
+++ b/pkg/plugins/builtin/subtask/subtask.go
@@ -132,7 +132,7 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 			cfg.Tags = map[string]string{}
 		}
 		cfg.Tags[constants.SubtaskTagParentTaskID] = stepContext.ParentTaskID
-		t, err = taskutils.CreateTask(ctx, dbp, tt, watcherUsernames, resolverUsernames, cfg.Input, nil, "Auto created subtask", cfg.Delay, cfg.Tags)
+		t, err = taskutils.CreateTask(ctx, dbp, tt, watcherUsernames, resolverUsernames, cfg.Input, nil, "Auto created subtask, parent task "+stepContext.ParentTaskID, cfg.Delay, cfg.Tags)
 		if err != nil {
 			dbp.Rollback()
 			return nil, nil, err


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the new behavior (if this is a feature change)?**
When a human operator modifies a task or a resolution, through a manual action, comment is added to indicate that the task/resolution have been manually modified (audit log like)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
