### PR TITLE
resource limiting: complete rework to handle context cancelation and native rate-limiting on a template

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -106,7 +106,7 @@ func (s *Server) ListenAndServe() error {
 		logrus.Info("Shutting down...")
 		cancel()
 
-		if err := srv.Shutdown(ctx); err != nil {
+		if err := srv.Shutdown(context.Background()); err != nil {
 			logrus.Fatal(err)
 		}
 	}()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -36,8 +36,8 @@ var (
 	eng Engine
 
 	// Used for stopping the current Engine
-	stopRunningSteps chan struct{}
-	gracePeriodEnd   chan struct{}
+	shutdownCtx    context.Context
+	gracePeriodEnd chan struct{}
 )
 
 // Engine is the heart of utask: it is the active process
@@ -97,13 +97,11 @@ func Init(ctx context.Context, wg *sync.WaitGroup, store *configstore.Store) err
 	}
 
 	// channels for handling graceful shutdown
-	stopRunningSteps = make(chan struct{})
+	shutdownCtx = ctx
 	gracePeriodEnd = make(chan struct{})
 	eng.wg = wg
 	go func() {
-		<-ctx.Done()
-		// Stop running new steps
-		close(stopRunningSteps)
+		<-shutdownCtx.Done()
 
 		// Wait for the grace period to end
 		time.Sleep(3 * time.Second)
@@ -215,14 +213,43 @@ func (e Engine) launchResolution(publicID string, async bool, sm *semaphore.Weig
 
 	res.Values.SetConfig(e.config)
 
-	// all ready, run remaining steps
-
-	utask.AcquireExecutionSlot()
-
+	// check if all resources are available before starting the resolution
+	// first, check if we have a custom semaphore, for example, a semaphore that limits the concurrent execution of tasks recovery from a crashed instance.
+	// This semaphore needs to go first, because it will always be smaller than the global execution pool.
 	if sm != nil {
-		sm.Acquire(context.Background(), 1)
+		if err := sm.Acquire(shutdownCtx, 1); err != nil {
+			debugLogger.Debugf("Engine: launchResolution() %s acquire resource: instance is shutting down", res.PublicID)
+			return nil, errors.New("instance is shutting down")
+		}
+	}
+	// second, check if we have a resource limit on the current template
+	// template could be completely deactivated as a "dead resource". If it's the case, we need to exit because
+	// the limit won't change until next instance's reboot.
+	if acquiredErr := utask.AcquireResource(shutdownCtx, "template:"+t.TemplateName); acquiredErr != nil {
+		if shutdownCtx.Err() != nil {
+			debugLogger.Debugf("Engine: launchResolution() %s acquire resource: instance is shutting down", res.PublicID)
+			return nil, errors.New("instance is shutting down")
+		}
+		debugLogger.Debugf("Engine: launchResolution() %s acquire resource %q: failed to acquire resource: %s", res.PublicID, "template:"+t.TemplateName, err)
+		// otherwise, we either reached timeout on the lock for template, or the template is a "dead resource"
+		t.SetState(task.StateBlocked)
+		res.SetNextRetry(time.Now().Add(10 * time.Minute))
+		res.SetState(resolution.StateToAutorunDelayed)
+		if err := commit(dbp, res, t); err != nil {
+			debugLogger.Debugf("Engine: launchResolution() %s acquire resource, FAILED TO COMMIT RESOLUTION: %s", res.PublicID, err)
+		}
+		if sm != nil {
+			sm.Release(1)
+		}
+		return nil, fmt.Errorf("can't acquire lock for template %q: %s", t.TemplateName, err)
+	}
+	// finally, acquire the execution slot
+	if acquiredErr := utask.AcquireExecutionSlot(shutdownCtx); acquiredErr != nil {
+		debugLogger.Debugf("Engine: launchResolution() %s acquire resource: instance is shutting down", res.PublicID)
+		return nil, errors.New("instance is shutting down")
 	}
 
+	// all ready, run remaining steps
 	recap := make([]string, 0)
 	for name, s := range res.Steps {
 		recap = append(recap, fmt.Sprintf("step %s = %s", name, s.State))
@@ -427,7 +454,7 @@ func resolve(dbp zesty.DBProvider, res *resolution.Resolution, t *task.Task, sm 
 
 	inShutdown := false
 	select {
-	case <-stopRunningSteps:
+	case <-shutdownCtx.Done():
 		inShutdown = true
 	default:
 	}
@@ -537,6 +564,7 @@ func resolve(dbp zesty.DBProvider, res *resolution.Resolution, t *task.Task, sm 
 		sm.Release(1)
 	}
 
+	utask.ReleaseResource("template:" + t.TemplateName)
 	utask.ReleaseExecutionSlot()
 	if err := resumeParentTask(dbp, t, sm, debugLogger); err != nil {
 		debugLogger.WithError(err).Debugf("Engine: resolver(): failed to resume parent task: %s", err)
@@ -602,7 +630,7 @@ func runAvailableSteps(dbp zesty.DBProvider, modifiedSteps map[string]bool, res 
 	expanded := 0
 
 	select {
-	case <-stopRunningSteps:
+	case <-shutdownCtx.Done():
 		return 0
 	default:
 		for name, s := range av {
@@ -660,7 +688,7 @@ func runAvailableSteps(dbp zesty.DBProvider, modifiedSteps map[string]bool, res 
 
 				// run
 				stepCopy := *s
-				step.Run(&stepCopy, res.BaseConfigurations, res.Values, stepChan, wg, stopRunningSteps)
+				step.Run(&stepCopy, res.BaseConfigurations, res.Values, stepChan, wg, shutdownCtx)
 			}
 		}
 	}


### PR DESCRIPTION
This introduces a complete rework of resource usage by implementing
contexts, so the lock can be cancelled, in case the lock takes too long
to be obtained, or if the instance is shutting-down.

It also introduces a native resource on all resolution based on the
template name: it allows to reduce the concurrent execution of a given
template, or to completely stop the execution of a template if it behave
incorrectly.

This also fix some dead-lock that can be triggered, if a resource limit is set to 0,
as the lock will never be obtained.