### PR TITLE
fix: RunResolution: prevent resolution manual run when maintenance mode is activated

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -333,6 +333,7 @@ func (s *Server) build(ctx context.Context) {
 					[]fizz.OperationOption{
 						fizz.Summary("Execute a task"),
 					},
+					maintenanceMode,
 					tonic.Handler(handler.RunResolution, 204))
 				resolutionRoutes.POST("/resolution/:id/pause",
 					[]fizz.OperationOption{


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

* **What is the current behavior?** (You can also link to an open issue here)
Manual run of resolution is permitted when maintenance mode is activated.
As maintenance mode should only allow read-only operation, it should prevent manual run of resolution as well.


* **What is the new behavior (if this is a feature change)?**
POST `/resolution/:id/run` now fails when maintenance mode is activated


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes.


* **Other information**:
