### PR TITLE
fix: GetResolution: all resolution manager should be allowed to retrieve outputs

### DIFF
--- a/api/handler/resolution.go
+++ b/api/handler/resolution.go
@@ -152,7 +152,17 @@ func GetResolution(c *gin.Context, in *getResolutionIn) (*resolution.Resolution,
 		return nil, err
 	}
 
-	if err := auth.IsResolver(c, r); err != nil {
+	t, err := task.LoadFromID(dbp, r.TaskID)
+	if err != nil {
+		return nil, err
+	}
+
+	tt, err := tasktemplate.LoadFromID(dbp, t.TemplateID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.IsResolutionManager(c, tt, t, r); err != nil {
 		r.ClearOutputs()
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Currently, only the user that resolved a task is allowed to see the outputs.
The current RBAC model inside µTask should allow every resolution managers of a template to see the outputs, as they are allowed to perform actions on this task.

* **What is the new behavior (if this is a feature change)?**
All resolution managers are allowed to see the outputs.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
