### PR TITLE
fix: squash the configuration items list

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -68,6 +68,10 @@ func Init(ctx context.Context, wg *sync.WaitGroup, store *configstore.Store) err
 	if err != nil {
 		return err
 	}
+	// Squash to ensure that secrets with lower priority
+	// are dismissed.
+	itemList = configstore.Filter().Squash().Apply(itemList)
+
 	// drop those that shouldnt be available for task execution
 	// (don't let DB credentials leak, for instance...)
 	config, err := filteredConfig(itemList, cfg.ConcealedSecrets...)


### PR DESCRIPTION
This ensure that items with a lower priority set by the provider
are dismissed.

Signed-off-by: William Poussier <william.poussier@ovhcloud.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Squash the `configstore` Items List that represents the configuration items.

* **What is the current behavior?** (You can also link to an open issue here)

No squash.

* **What is the new behavior (if this is a feature change)?**

Squash is applied, items with lower priority are dismissed if there is already
another item(s) with a higher priority that shares the same key.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, but no. Current behavior is incorrect anyway.

