### PR TITLE
fix: sql migration 1.10.0: handle null last_start on resolution

### DIFF
--- a/sql/migrations/005_resolution_creation_timestamp.sql
+++ b/sql/migrations/005_resolution_creation_timestamp.sql
@@ -3,6 +3,7 @@
 -- Adds the resolution creation timestamp on resolution table and sets its value to last_start
 ALTER TABLE "resolution" ADD COLUMN "created" TIMESTAMP with time zone;
 UPDATE "resolution" SET created = last_start;
+UPDATE "resolution" SET created = NOW() WHERE created IS NULL;
 ALTER TABLE "resolution" ALTER COLUMN "created" SET NOT NULL, ALTER COLUMN "created" SET DEFAULT now();
 
 -- +migrate Down


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix SQL migration


* **What is the current behavior?** (You can also link to an open issue here)
Unable to apply migration


* **What is the new behavior (if this is a feature change)?**
When some resolution are created before never run (for example, due to
TO_AUTORUN_DELAYED, or when a manual resolving is needed), last_start
property is NULL, which is incompatible with the NOT NULL statement for
created property. This ALTER corrects the issue.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Mandatory for 1.10 release