### PR TITLE
db: check that latest SQL migration is applied before starting µTask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,49 @@
 os:
-  - linux
+    - linux
 dist: bionic
 
 language: go
 go:
-  - "1.15"
-  - "1.14"
-  - "1.13"
-  - "master"
+    - "1.15"
+    - "master"
 go_import_path: github.com/ovh/utask
 
 cache: apt
 
 services:
-  - postgresql
+    - postgresql
 addons:
-  postgresql: "9.5"
+    postgresql: "9.5"
 
 env:
-  global:
-    - GO111MODULE=on
-    - DEV=true
-    - PG_USER=travis
-    - PG_PASSWORD=travispwd
-    - PG_HOST=localhost
-    - PG_PORT=5432
-    - PG_DATABASENAME=travisdb
-    - PSQL_BIN="psql travisdb"
+    global:
+        - GO111MODULE=on
+        - DEV=true
+        - PG_USER=travis
+        - PG_PASSWORD=travispwd
+        - PG_HOST=localhost
+        - PG_PORT=5432
+        - PG_DATABASENAME=travisdb
+        - PSQL_BIN="psql travisdb"
 
 before_script:
-  - psql -c 'create database travisdb;' -U postgres
+    - psql -c 'create database travisdb;' -U postgres
 
 # we could also use YAML aliases for Golang steps https://docs.travis-ci.com/user/build-stages/using-yaml-aliases/
 script:
-  - make test-travis
-  - make release
+    - make test-travis
+    - make release
 
 after_success:
-  - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN # upload coverage.out results to goveralls plateform
+    - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN # upload coverage.out results to goveralls plateform
 
 jobs:
-  include:
-    - name: test docker build
-      script: docker build -t utask-dev ./
-      language: shell
-      addons: {}
-      before_script: echo "override before_script"
-      after_success: echo "override after_success"
-  allow_failures:
-    - go: master
+    include:
+        - name: test docker build
+          script: docker build -t utask-dev ./
+          language: shell
+          addons: {}
+          before_script: echo "override before_script"
+          after_success: echo "override after_success"
+    allow_failures:
+        - go: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN BASEHREF=___UTASK_DASHBOARD_BASEHREF___ PREFIX_API_BASE_URL=___UTASK_DASHBOA
 WORKDIR /home/node/ui/editor
 RUN BASEHREF=___UTASK_EDITOR_BASEHREF___ SENTRY_DSN=___UTASK_DASHBOARD_SENTRY_DSN___ make build-prod
 
-FROM golang:1.14-buster
+FROM golang:1.15-buster
 
 COPY .  /go/src/github.com/ovh/utask
 WORKDIR /go/src/github.com/ovh/utask

--- a/db/init.go
+++ b/db/init.go
@@ -103,6 +103,11 @@ func Init(store *configstore.Store) error {
 	if err := now.Init(); err != nil {
 		return err
 	}
+
+	if err := migrationChecker(); err != nil {
+		return err
+	}
+
 	return models.Init(store)
 }
 

--- a/db/migration.go
+++ b/db/migration.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"fmt"
+
+	_ "github.com/lib/pq" // postgresql driver
+	"github.com/loopfz/gadgeto/zesty"
+
+	"github.com/ovh/utask"
+	"github.com/ovh/utask/db/sqlgenerator"
+)
+
+const (
+	expectedVersion = "v1.10.0-migration005"
+)
+
+// migrationChecker make sure that the latest SQL migration is correctly applied
+// otherwise, fails to start µTask.
+func migrationChecker() error {
+	dbp, err := zesty.NewDBProvider(utask.DBName)
+	if err != nil {
+		return err
+	}
+
+	sel := sqlgenerator.PGsql.Select(
+		`"utask_sql_migrations".current_migration_applied`,
+	).From(
+		`"utask_sql_migrations"`,
+	).Limit(1)
+
+	query, params, err := sel.ToSql()
+	if err != nil {
+		return err
+	}
+
+	row := dbp.DB().QueryRow(query, params...)
+	if err := row.Err(); err != nil {
+		return fmt.Errorf("unable to start µTask: missing latest SQL migration: %s", err)
+	}
+
+	var version string
+	if err := row.Scan(&version); err != nil {
+		return fmt.Errorf("unable to start µTask: missing latest SQL migration: %s", err)
+	}
+	if version != expectedVersion {
+		return fmt.Errorf("unable to start µTask: missing latest SQL migration: expected %q, found %q", expectedVersion, version)
+	}
+
+	return nil
+}

--- a/sql/migrations/005_resolution_creation_timestamp.sql
+++ b/sql/migrations/005_resolution_creation_timestamp.sql
@@ -6,6 +6,13 @@ UPDATE "resolution" SET created = last_start;
 UPDATE "resolution" SET created = NOW() WHERE created IS NULL;
 ALTER TABLE "resolution" ALTER COLUMN "created" SET NOT NULL, ALTER COLUMN "created" SET DEFAULT now();
 
+CREATE TABLE "utask_sql_migrations" (
+    current_migration_applied TEXT PRIMARY KEY
+);
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.10.0-migration005');
+
 -- +migrate Down
 
 ALTER TABLE "resolution" DROP COLUMN "created";
+DROP TABLE "utask_sql_migrations";

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -105,4 +105,10 @@ CREATE TABLE "runner_instance" (
     heartbeat TIMESTAMP with time zone DEFAULT now() NOT NULL
 );
 
+CREATE TABLE "utask_sql_migrations" (
+    current_migration_applied TEXT PRIMARY KEY
+);
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.10.0-migration005');
+
 END;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
When SQL migration is needed for a new µTask release, if the migration is not applied, this could lead to µTask having erratic internal server errors

* **What is the new behavior (if this is a feature change)?**
µTask now checks that the latest migration is correctly applied before starting.
This prevent bumping the µTask version without applying the migration.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
