### PR TITLE
feat(ui): 'all' filter for user, use inputs from task or template

### DIFF
--- a/ui/dashboard/projects/utask-lib/src/lib/@components/editor/editor.component.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@components/editor/editor.component.ts
@@ -1,12 +1,13 @@
-import { Component, ElementRef, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { Component, ElementRef, Input, Output, EventEmitter, OnChanges, OnInit } from '@angular/core';
 import { EditorOptions } from 'ng-zorro-antd/code-editor';
+import { NzConfigService } from 'ng-zorro-antd/core/config';
 
 @Component({
     selector: 'lib-utask-editor',
     templateUrl: './editor.html',
     styleUrls: ['./editor.sass']
 })
-export class EditorComponent implements OnChanges {
+export class EditorComponent implements OnInit, OnChanges {
     @Input() set config(c: EditorOptions) {
         this._config = {
             minimap: { enabled: false },
@@ -19,10 +20,26 @@ export class EditorComponent implements OnChanges {
     @Input() ngModel: string;
     @Output() ngModelChange = new EventEmitter<string>();
 
-    constructor(private elRef: ElementRef) { }
+    constructor(
+        private _el: ElementRef,
+        private _nzConfigService: NzConfigService
+    ) { }
+
+    ngOnInit(): void {
+        this.computeTheme();
+        this._nzConfigService.getConfigChangeEventForComponent('codeEditor').subscribe(_ => {
+            this.computeTheme();
+        });
+    }
 
     ngOnChanges(): void {
         const height = (this.ngModel.split('\n').length + 1) * 18;
-        this.elRef.nativeElement.style.height = `${height}px`;
+        this._el.nativeElement.style.height = `${height}px`;
+    }
+
+    computeTheme(): void {
+        const editorConfig = this._nzConfigService.getConfigForComponent('codeEditor');
+        const theme = editorConfig?.defaultEditorOption?.theme;
+        this._el.nativeElement.style.borderColor = theme === 'vs-dark' ? '#434343' : '#d9d9d9';
     }
 }

--- a/ui/dashboard/projects/utask-lib/src/lib/@components/editor/editor.sass
+++ b/ui/dashboard/projects/utask-lib/src/lib/@components/editor/editor.sass
@@ -1,3 +1,4 @@
 :host
 	display: block
 	overflow: hidden
+	border: 1px solid #d9d9d9

--- a/ui/dashboard/projects/utask-lib/src/lib/@models/task.model.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@models/task.model.ts
@@ -24,7 +24,8 @@ export class ResolutionStep {
 export enum TaskType {
     all = 'all',
     own = 'own',
-    resolvable = 'resolvable',
+    both = 'both',
+    resolvable = 'resolvable'
 };
 
 export enum TaskState {
@@ -33,7 +34,7 @@ export enum TaskState {
     DONE = 'DONE',
     RUNNING = 'RUNNING',
     TODO = 'TODO',
-    WONTFIX = 'WONTFIX',
+    WONTFIX = 'WONTFIX'
 };
 
 export class Comment {
@@ -71,6 +72,7 @@ export default class Task {
     title: string;
     watcher_usernames: string[];
     tags: { [key: string]: string };
+    resolver_inputs: any[];
 
     public constructor(init?: Partial<Task>) {
         Object.assign(this, init);

--- a/ui/dashboard/projects/utask-lib/src/lib/@routes/task/task.html
+++ b/ui/dashboard/projects/utask-lib/src/lib/@routes/task/task.html
@@ -160,12 +160,11 @@
                 Resolve this task
             </div>
             <div app-box-content>
-                <lib-utask-inputs-form *ngIf="template" [formGroup]="validateResolveForm"
-                    [inputs]="template.resolver_inputs">
+                <lib-utask-inputs-form [formGroup]="validateResolveForm" [inputs]="resolverInputs">
                 </lib-utask-inputs-form>
                 <form nz-form [formGroup]="validateResolveForm" (ngSubmit)="resolveTask()">
                     <nz-form-item nz-row class="register-area">
-                        <nz-form-control [nzSpan]="14" [nzOffset]="template.resolver_inputs ? 6 : 1">
+                        <nz-form-control [nzSpan]="14" [nzOffset]="resolverInputs ? 6 : 1">
                             <button nz-button nzType="primary" [disabled]="!validateResolveForm.valid"
                                 [nzLoading]="loaders.resolveTask">Resolve</button>
                         </nz-form-control>
@@ -182,14 +181,14 @@
             <div app-box-content>
                 <form nz-form [formGroup]="validateRejectForm" (ngSubmit)="rejectTask()">
                     <nz-form-item nz-row class="register-area">
-                        <nz-form-control [nzSpan]="14" [nzOffset]="template.resolver_inputs ? 6 : 1">
+                        <nz-form-control [nzSpan]="14" [nzOffset]="resolverInputs ? 6 : 1">
                             <label formControlName="agree" nz-checkbox>
                                 Are you sure you want to reject this request ?
                             </label>
                         </nz-form-control>
                     </nz-form-item>
                     <nz-form-item nz-row class="register-area">
-                        <nz-form-control [nzSpan]="14" [nzOffset]="template.resolver_inputs ? 6 : 1">
+                        <nz-form-control [nzSpan]="14" [nzOffset]="resolverInputs ? 6 : 1">
                             <button nz-button nzType="danger" [disabled]="!validateRejectForm.valid"
                                 [nzLoading]="loaders.rejectTask">Reject</button>
                         </nz-form-control>

--- a/ui/dashboard/projects/utask-lib/src/lib/@routes/tasks/tasks.component.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@routes/tasks/tasks.component.ts
@@ -82,7 +82,7 @@ export class TasksComponent implements OnInit {
     const params = new ParamsListTasks();
     const pageSize = parseInt(queryParams.page_size, 10)
     params.page_size = pageSize && 10 <= pageSize && pageSize <= 1000 ? pageSize : 10;
-    const defaultType = this.meta.user_is_admin ? 'all' : 'own';
+    const defaultType = this.meta.user_is_admin ? TaskType.all : TaskType.both;
     params.type = queryParams.type || defaultType;
     params.last = '';
     params.state = queryParams.state || '';

--- a/ui/dashboard/projects/utask-lib/src/lib/@routes/tasks/tasks.html
+++ b/ui/dashboard/projects/utask-lib/src/lib/@routes/tasks/tasks.html
@@ -5,7 +5,7 @@
                 <nz-form-label>Type</nz-form-label>
                 <nz-form-control>
                     <nz-select [ngModel]="pagination.type" (ngModelChange)="paginationTypeChange($event)">
-                        <nz-option *ngIf="meta.user_is_admin" nzValue="all" nzLabel="All"></nz-option>
+                        <nz-option [nzValue]="meta.user_is_admin ? 'all' : 'both'" nzLabel="All"></nz-option>
                         <nz-option nzValue="own" nzLabel="As a requester"></nz-option>
                         <nz-option nzValue="resolvable" nzLabel="As a resolver"></nz-option>
                     </nz-select>

--- a/ui/dashboard/projects/utask-lib/src/lib/@routes/tasks/tasks.sass
+++ b/ui/dashboard/projects/utask-lib/src/lib/@routes/tasks/tasks.sass
@@ -3,9 +3,14 @@
   display: flex
   flex-direction: column
 
-lib-utask-input-tags
-  flex: 1
-  overflow: hidden
+nz-form-item
+  width: 100%
+  display: flex
+  flex-direction: row
+
+  nz-form-control
+    flex: 1
+    overflow: hidden
 
 lib-utask-tasks-list
   flex: 1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add a new type filters for tasks (all) for non admin user that combines results from resolvable and own tasks.
Use inputs definition from tasks.inputs_resolver if template is not visible.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
* WAITING merge of #202 , need to change target branch to master when ok
