### PR TITLE
pkg/notify: add notification strategies regarding template name and state

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -48,6 +48,10 @@ postgres://user:pass@db/utask?sslmode=disable
     // - tat (github.com/ovh/tat)
     // - slack webhook (https://api.slack.com/messaging/webhooks)
     // - generic webhook (custom URL, with HTTP POST method)
+    // notification strategies can be declared per backend:
+    // - template_notification_strategies is an array of strategy per template
+    // - default_notification_strategy is the strategy that will apply, if none matched above
+    // available strategies are: always, failure_only, silent
     "notify_config": {
         "tat-internal": {
             "type": "tat",
@@ -56,13 +60,19 @@ postgres://user:pass@db/utask?sslmode=disable
                 "password": "very-secret",
                 "url": "http://localhost:9999/tat",
                 "topic": "utask.notifications"
-            }
+            },
+            "default_notification_strategy":"silent",
+            "template_notification_strategies": [{
+                "templates": ["hello-world", "hello-world-2"],
+                "notification_strategy": "always"
+            }]
         },
         "slack-webhook": {
             "type": "slack",
             "config": {
                 "webhook_url": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
-            }
+            },
+            "default_notification_strategy":"failure_only"
         },
         "webhook-example.org": {
             "type": "webhook",
@@ -110,6 +120,8 @@ postgres://user:pass@db/utask?sslmode=disable
     // delay_between_crashed_tasks_resolution defines a wait duration between two tasks from a crashed instance will be schedule in the current uTask instance
     // default 1, unit: seconds
     "delay_between_crashed_tasks_resolution": 1,
+    // base_url defines the base URL for the µTask UI. It's used for determining the public URL of a task, for notification purposes. dashboard_path_prefix will be appended to this URL.
+    "base_url": "https://utask.example.org",
     // dashboard_path_prefix defines the path prefix for the dashboard UI. Should be used if the uTask instance is hosted with a ProxyPass, on a custom path
     // default: empty, no prefix
     "dashboard_path_prefix": "/my-utask-instance",

--- a/utask.go
+++ b/utask.go
@@ -86,6 +86,13 @@ const (
 
 	// UtaskCfgSecretAlias is the key for the config item containing global configuration data
 	UtaskCfgSecretAlias = "utask-cfg"
+
+	// NotificationStrategySilent corresponds to the mode where notifications will never be sent for the given templates
+	NotificationStrategySilent = "silent"
+	// NotificationStrategyAlways corresponds to the mode where notifications will always be sent for the given templates
+	NotificationStrategyAlways = "always"
+	// NotificationStrategyFailureOnly corresponds to the mode where notifications will only be sent if the state is BLOCKED
+	NotificationStrategyFailureOnly = "failure_only"
 )
 
 // Cfg holds global configuration data
@@ -105,6 +112,7 @@ type Cfg struct {
 	MaxConcurrentExecutionsFromCrashedComputed int                      `json:"-"`
 	DelayBetweenCrashedTasksResolution         string                   `json:"delay_between_crashed_tasks_resolution"`
 	InstanceCollectorWaitDuration              time.Duration            `json:"-"`
+	BaseURL                                    string                   `json:"base_url"`
 	DashboardPathPrefix                        string                   `json:"dashboard_path_prefix"`
 	DashboardAPIPathPrefix                     string                   `json:"dashboard_api_path_prefix"`
 	DashboardSentryDSN                         string                   `json:"dashboard_sentry_dsn"`
@@ -123,8 +131,16 @@ type ServerOpt struct {
 
 // NotifyBackend holds configuration for instantiating a notify client
 type NotifyBackend struct {
-	Type   string          `json:"type"`
-	Config json.RawMessage `json:"config"`
+	Type                           string                         `json:"type"`
+	Config                         json.RawMessage                `json:"config"`
+	TemplateNotificationStrategies []TemplateNotificationStrategy `json:"template_notification_strategies"`
+	DefaultNotificationStrategy    string                         `json:"default_notification_strategy"` // can be `always`, `failure_only`, `silent`
+}
+
+// TemplateNotificationStrategy configures how a NotifyBackend should behave for a given set of templates
+type TemplateNotificationStrategy struct {
+	Templates            []string `json:"templates"`
+	NotificationStrategy string   `json:"notification_strategy"` // can be `always`, `failure_only`, `silent`
 }
 
 // NotifyBackendTat holds configuration for instantiating a Tat notify client


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the new behavior (if this is a feature change)?**
Notification strategies allows µTask administrator to control when the
notification should be sent to a given notification backend. It can
control if the notification should be sent regarding the template used
by a task, or regarding the current state of the task.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
