### PR TITLE
resolution: allow resolution edition on a single step + add endpoint to change only step state

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -354,6 +354,27 @@ func (s *Server) build(ctx context.Context) {
 					},
 					maintenanceMode,
 					tonic.Handler(handler.CancelResolution, 204))
+				resolutionRoutes.GET("/resolution/:id/step/:stepName",
+					[]fizz.OperationOption{
+						fizz.Summary("Get the details of the step of a task resolution"),
+						fizz.Description("Returns the current implementation of the step, including the output of the step."),
+					},
+					tonic.Handler(handler.GetResolutionStep, 200))
+				resolutionRoutes.PUT("/resolution/:id/step/:stepName",
+					[]fizz.OperationOption{
+						fizz.Summary("Edit the details of the step of a task resolution"),
+						fizz.Description("Allow the edition of a step, if a step needs fixing. Admin users only."),
+					},
+					requireAdmin,
+					maintenanceMode,
+					tonic.Handler(handler.UpdateResolutionStep, 204))
+				resolutionRoutes.PUT("/resolution/:id/step/:stepName/state",
+					[]fizz.OperationOption{
+						fizz.Summary("Edit the state of the step of a task resolution"),
+						fizz.Description("Allow the edition of the step state, if a step needs to be re-run or skipped manually. Resolution managers only."),
+					},
+					maintenanceMode,
+					tonic.Handler(handler.UpdateResolutionStepState, 204))
 
 				//	resolutionRoutes.POST("/resolution/:id/rollback",
 				//		[]fizz.OperationOption{

--- a/engine/step/step.go
+++ b/engine/step/step.go
@@ -722,6 +722,27 @@ func (s *Step) GetPreHook() (*executor.Executor, error) {
 
 }
 
+func (s *Step) CheckIfValidState() (bool, error) {
+	for _, state := range builtinStates {
+		if state == s.State {
+			return true, nil
+		}
+	}
+
+	states, err := s.GetCustomStates()
+	if err != nil {
+		return false, err
+	}
+
+	for _, state := range states {
+		if state == s.State {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func annotateFunctions(functions []string, err error) error {
 	for _, function := range functions {
 		err = errors.Annotate(err, fmt.Sprintf("function %q", function))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the new behavior (if this is a feature change)?**
Adding 3 new API endpoint to retrieve the value of a given step
resolution, edit the content of a given step resolution, and edit the
state of a given step resolution.
This allow a more granular edition, which prevent massive resolution
edition by multiple human operators that would override themselves.

Edition of the state of a given step resolution is allowed to Resolution
Managers, as it would not put any risk to the resolution consistency.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
