### PR TITLE
feat(script): declare environment variables with task context (#226)

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -945,6 +945,27 @@ func TestScriptPlugin(t *testing.T) {
 	assert.Equal(t, metadata, metadataOutput)
 }
 
+func TestScriptPluginEnvironmentVariables(t *testing.T) {
+	res, err := createResolution("execScriptWithEnvironment.yaml", map[string]interface{}{}, nil)
+	assert.NotNil(t, res)
+	assert.Nil(t, err)
+
+	res, err = runResolution(res)
+	assert.NotNil(t, res)
+	assert.Nil(t, err)
+
+	assert.NotNil(t, res.Steps["stepOne"].Output)
+
+	environment := res.Steps["stepOne"].Output.(map[string]interface{})
+
+	assert.NotNil(t, environment["UTASK_TASK_ID"])
+	assert.Equal(t, res.TaskPublicID, environment["UTASK_TASK_ID"])
+	assert.NotNil(t, environment["UTASK_RESOLUTION_ID"])
+	assert.Equal(t, res.PublicID, environment["UTASK_RESOLUTION_ID"])
+	assert.NotNil(t, environment["UTASK_STEP_NAME"])
+	assert.Equal(t, "stepOne", environment["UTASK_STEP_NAME"])
+}
+
 func TestBaseBaseConfiguration(t *testing.T) {
 	res, err := createResolution("base_configuration.yaml", nil, nil)
 	assert.NotNil(t, res)

--- a/engine/scripts_tests/env-vars.py
+++ b/engine/scripts_tests/env-vars.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import json
+import os
+
+content = {
+    k: v for k, v in os.environ.items()
+}
+
+print(json.dumps(content))

--- a/engine/templates_tests/execScriptWithEnvironment.yaml
+++ b/engine/templates_tests/execScriptWithEnvironment.yaml
@@ -1,0 +1,32 @@
+name: exec-script-with-environment
+description: Executing a shell script that returns environment variables
+title_format: "[test] a simple task for script-plugin to verify environment variables"
+
+steps:
+    stepOne:
+        description: first step
+        action:
+            type: script
+            configuration:
+                #   ____________________
+                #  /                    \
+                # |  This is only for    |
+                # |   testing purpose    |
+                #  \____________________/
+                #          !  !
+                #          !  !
+                #          L_ !
+                #         / _)!
+                #        / /__L
+                #  _____/ (____)
+                #         (____)
+                #  _____  (____)
+                #       \_(____)
+                #          !  !
+                #          !  !
+                #          \__/
+                # This file param is valid only in a testing context
+                # In production, `file` will be prefixed by the utask.FScriptsFolder variable ("./scripts" by default)
+                # You can specify your file's path relative to that location
+                file_path: "./scripts_tests/env-vars.py"
+                timeout_seconds: "25"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds environment variables in script plugin executions:
* UTASK_TASK_ID with the task ID
* UTASK_RESOLUTION_ID with the resolution ID
* UTASK_STEP_NAME with the step name

* **What is the current behavior?** (You can also link to an open issue here)

Currently, no environment variable is declared


* **What is the new behavior (if this is a feature change)?**

The environment variables are available from the script execution context.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking change

* **Other information**:

N/A