### PR TITLE
fix(http): do not include host as resources if unable to parse URL

### DIFF
--- a/pkg/plugins/builtin/apiovh/apiovh.go
+++ b/pkg/plugins/builtin/apiovh/apiovh.go
@@ -95,7 +95,7 @@ func resourcesapiovh(i interface{}) []string {
 	}
 	if host, ok := ovh.Endpoints[endpoint]; ok {
 		uri, _ := url.Parse(host)
-		if uri.Host != "" {
+		if uri != nil && uri.Host != "" {
 			resources = append(resources, "url:"+uri.Host)
 		}
 	}

--- a/pkg/plugins/builtin/http/http.go
+++ b/pkg/plugins/builtin/http/http.go
@@ -156,10 +156,14 @@ func resourceshttp(i interface{}) []string {
 	var host string
 	if cfg.Host == "" {
 		uri, _ := url.Parse(cfg.URL)
-		host = uri.Host
+		if uri != nil {
+			host = uri.Host
+		}
 	} else {
 		uri, _ := url.Parse(cfg.Host)
-		host = uri.Host
+		if uri != nil {
+			host = uri.Host
+		}
 	}
 
 	if host == "" {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the new behavior (if this is a feature change)?**
In case we have an invalid URL, plugin http and apiovh should not include the invalid host as resource


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Reported by @rclsilver 