### PR TITLE
ui: fix the context menu on the d3 graph on firefox

### DIFF
--- a/ui/dashboard/projects/utask-lib/src/lib/@components/steps-viewer/steps-viewer.html
+++ b/ui/dashboard/projects/utask-lib/src/lib/@components/steps-viewer/steps-viewer.html
@@ -1,2 +1,4 @@
-<svg #svg oncontextmenu="return false;"></svg>
-<button type="button" nz-button nzSize="large" (click)="center()"><i nz-icon nzType="aim"></i></button>
+<div oncontextmenu="return false;">
+    <svg #svg></svg>
+    <button nz-button nzSize="large" (click)="center()"><i nz-icon nzType="aim"></i></button>
+</div>

--- a/ui/dashboard/projects/utask-lib/src/lib/@components/steps-viewer/steps-viewer.sass
+++ b/ui/dashboard/projects/utask-lib/src/lib/@components/steps-viewer/steps-viewer.sass
@@ -4,6 +4,10 @@
     height: 100%
     position: relative
 
+
+div
+    height: 100%
+
 svg
     width: 100%
     height: 100%


### PR DESCRIPTION
Signed-off-by: Simon Martinez <1263852+simonmartinez@users.noreply.github.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix a bug on firefox: Disable the context menu on the d3 graph


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
