### PR TITLE
log: change request hostname to request_host

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -34,7 +34,7 @@ func auditLogsMiddleware(c *gin.Context) {
 		"user_agent":      c.Request.UserAgent(),
 		"duration":        requestDuration.Seconds(),
 		"duration_ms":     requestDuration.Milliseconds(),
-		"host":            c.Request.Host,
+		"request_host":    c.Request.Host,
 		"remote_ip":       c.ClientIP(),
 		"runner_instance": utask.InstanceID,
 		"request_id":      c.Request.Header.Get(requestIDHeader),


### PR DESCRIPTION
GELF specification have a reserved field named 'host' that should
contains the hostname of the system emitting the logs. If µTask runs on
an infrastructure that contains multiples instances, it's interesting to
not override this field.
