### PR TITLE
collector: switch to SKIP LOCKED

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ A task will keep running as long as its steps are successfully executed. If a ta
 7. De-activate maintenance mode.
 8. Reboot API.
 
+### Dependencies
+
+The only dependency for µTask is a Postgres database server. The minimum version for the Postgres database is 9.5
+
 ## Configuration 🔨 <a name="configuration"></a>
 
 ### Command line args

--- a/engine/collector_autorun.go
+++ b/engine/collector_autorun.go
@@ -54,9 +54,8 @@ func getUpdateAutorunResolution(dbp zesty.DBProvider) (*resolution.Resolution, e
 			FROM "resolution"
 			WHERE (state = $3 OR
 				  (instance_id = $1 AND state = $2))
-			AND pg_try_advisory_xact_lock(id)
 			LIMIT 1
-			FOR UPDATE
+			FOR UPDATE SKIP LOCKED
 		)
 		RETURNING id, public_id`
 

--- a/engine/collector_instance.go
+++ b/engine/collector_instance.go
@@ -102,9 +102,8 @@ func getUpdateRunningResolution(dbp zesty.DBProvider, i *runnerinstance.Instance
 			FROM "resolution"
 			WHERE ((instance_id = $3 AND state IN ($2,$4,$5,$6)) OR
 				   (instance_id = $1 AND state = $2))
-     	 	AND pg_try_advisory_xact_lock(id)
 			LIMIT 1
-			FOR UPDATE
+			FOR UPDATE SKIP LOCKED
 		)
 		RETURNING id, public_id`
 

--- a/engine/collector_retry.go
+++ b/engine/collector_retry.go
@@ -54,9 +54,8 @@ func getUpdateErrorResolution(dbp zesty.DBProvider) (*resolution.Resolution, err
 			FROM "resolution"
 			WHERE ((instance_id = $1 AND state = $2) OR
 				  ((state = $3 OR state = $4) AND next_retry < NOW()))
-			AND pg_try_advisory_xact_lock(id)
 			LIMIT 1
-			FOR UPDATE
+			FOR UPDATE SKIP LOCKED
 		)
 		RETURNING id, public_id`
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

When µTask is used with a lot of tasks, lock on the postgres can take
a lot of memory as the `pg_try_advisory_xact_lock` lock function will
try to lock all the rows. As Postgres 9.5+ now handle `SKIP LOCKED`
keyword, it can be used to try to acquire only one row, without locking
all the existing resolution. The lock will also be scopped at the table
level, instead of the Postgres cluster level previously.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
