### PR TITLE
feat(auth): Add group support #235

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,10 @@ A process that can be executed by µTask is modelled as a `task template`: it is
 
 The user that creates a task is called `requester`, and the user that executes it is called `resolver`. Both can be the same user in some scenarios.
 
-A user can be allowed to resolve a task in three ways:
+A user can be allowed to resolve a task in four ways:
 - the user is included in the global configuration's list of `admin_usernames`
 - the user is included in the task's template list of `allowed_resolver_usernames`
+- the user is in a group that is included in the task's template list of `allowed_resolver_groups`
 - the user is included in the task `resolver_usernames` list
 
 ### Value Templating
@@ -269,6 +270,7 @@ The following templating functions are available:
 
 ### Advanced properties
 
+- `allowed_resolver_groups`: a list of groups with the right to resolve a task based on this template
 - `allowed_resolver_usernames`: a list of usernames with the right to resolve a task based on this template
 - `allow_all_resolver_usernames`: boolean (default: false): when true, any user can execute a task based on this template
 - `auto_runnable`; boolean (default: false): when true, the task will be executed directly after being created, IF the requester is an accepted resolver or `allow_all_resolver_usernames` is true
@@ -811,7 +813,7 @@ type InitializerPlugin interface {
 
 As of version `v1.0.0`, this is meant to give you access to two features:
 - `service.Store` exposes the `RegisterProvider(name string, f configstore.Provider)` method that allow you to plug different data sources for you configuration, which are not available by default in the main runtime
-- `service.Server` exposes the `WithAuth(authProvider func(*http.Request) (string, error))` method, where you can provide a custom source of authentication and authorization based on the incoming http requests
+- `service.Server` exposes the `WithAuth(authProvider func(*http.Request) (string, error))` and `WithGroupAuth(groupAuthProvider func(*http.Request) (string, []string, error))` methods, where you can provide a custom source of authentication and authorization based on the incoming http requests
 
 If you develop more than one initialization plugin, they will all be loaded in alphabetical order. You might want to provide a default initialization, plus more specific behaviour under certain scenarios.
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -413,7 +413,7 @@ func TestPagination(t *testing.T) {
 	cnt := 20
 	var midTask task.Task
 	for i := 0; i < cnt; i++ {
-		tsk, err := task.Create(dbp, tmpl, regularUser, nil, nil, nil, nil, map[string]interface{}{"id": strconv.Itoa(i)}, nil, nil)
+		tsk, err := task.Create(dbp, tmpl, regularUser, nil, nil, nil, nil, nil, map[string]interface{}{"id": strconv.Itoa(i)}, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -413,7 +413,7 @@ func TestPagination(t *testing.T) {
 	cnt := 20
 	var midTask task.Task
 	for i := 0; i < cnt; i++ {
-		tsk, err := task.Create(dbp, tmpl, regularUser, nil, nil, map[string]interface{}{"id": strconv.Itoa(i)}, nil, nil)
+		tsk, err := task.Create(dbp, tmpl, regularUser, nil, nil, nil, map[string]interface{}{"id": strconv.Itoa(i)}, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -413,7 +413,7 @@ func TestPagination(t *testing.T) {
 	cnt := 20
 	var midTask task.Task
 	for i := 0; i < cnt; i++ {
-		tsk, err := task.Create(dbp, tmpl, regularUser, nil, nil, nil, map[string]interface{}{"id": strconv.Itoa(i)}, nil, nil)
+		tsk, err := task.Create(dbp, tmpl, regularUser, nil, nil, nil, nil, map[string]interface{}{"id": strconv.Itoa(i)}, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/handler/batch.go
+++ b/api/handler/batch.go
@@ -61,7 +61,7 @@ func CreateBatch(c *gin.Context, in *createBatchIn) (*task.Batch, error) {
 			return nil, err
 		}
 
-		_, err = taskutils.CreateTask(c, dbp, tt, in.WatcherUsernames, []string{}, input, b, in.Comment, nil, in.Tags)
+		_, err = taskutils.CreateTask(c, dbp, tt, in.WatcherUsernames, []string{}, []string{}, input, b, in.Comment, nil, in.Tags)
 		if err != nil {
 			dbp.Rollback()
 			return nil, err

--- a/api/handler/batch.go
+++ b/api/handler/batch.go
@@ -19,6 +19,7 @@ type createBatchIn struct {
 	Inputs           []map[string]interface{} `json:"inputs" binding:"required"`
 	Comment          string                   `json:"comment"`
 	WatcherUsernames []string                 `json:"watcher_usernames"`
+	WatcherGroups    []string                 `json:"watcher_groups"`
 	Tags             map[string]string        `json:"tags"`
 }
 
@@ -61,7 +62,7 @@ func CreateBatch(c *gin.Context, in *createBatchIn) (*task.Batch, error) {
 			return nil, err
 		}
 
-		_, err = taskutils.CreateTask(c, dbp, tt, in.WatcherUsernames, []string{}, []string{}, input, b, in.Comment, nil, in.Tags)
+		_, err = taskutils.CreateTask(c, dbp, tt, in.WatcherUsernames, in.WatcherGroups, []string{}, []string{}, input, b, in.Comment, nil, in.Tags)
 		if err != nil {
 			dbp.Rollback()
 			return nil, err

--- a/api/handler/task.go
+++ b/api/handler/task.go
@@ -168,9 +168,11 @@ func ListTasks(c *gin.Context, in *listTasksIn) (t []*task.Task, err error) {
 		filter.RequesterUser = user
 	case taskTypeResolvable:
 		filter.PotentialResolverUser = user
+		filter.PotentialResolverGroups = auth.GetGroups(c)
 	case taskTypeAll:
 		if err2 := auth.IsAdmin(c); err2 != nil {
 			filter.RequesterOrPotentialResolverUser = user
+			filter.RequesterOrPotentialResolverGroups = auth.GetGroups(c)
 		}
 	default:
 		return nil, errors.BadRequestf("Unknown type for listing: '%s'. Was expecting '%s', '%s' or '%s'", in.Type, taskTypeOwn, taskTypeResolvable, taskTypeAll)

--- a/api/handler/task.go
+++ b/api/handler/task.go
@@ -28,6 +28,7 @@ type createTaskIn struct {
 	Input             map[string]interface{} `json:"input" binding:"required"`
 	Comment           string                 `json:"comment"`
 	WatcherUsernames  []string               `json:"watcher_usernames"`
+	WatcherGroups     []string               `json:"watcher_groups"`
 	ResolverUsernames []string               `json:"resolver_usernames"`
 	ResolverGroups    []string               `json:"resolver_groups"`
 	Delay             *string                `json:"delay"`
@@ -79,7 +80,7 @@ func CreateTask(c *gin.Context, in *createTaskIn) (*task.Task, error) {
 		}
 	}
 
-	t, err := taskutils.CreateTask(c, dbp, tt, in.WatcherUsernames, in.ResolverUsernames, in.ResolverGroups, in.Input, nil, in.Comment, in.Delay, in.Tags)
+	t, err := taskutils.CreateTask(c, dbp, tt, in.WatcherUsernames, in.WatcherGroups, in.ResolverUsernames, in.ResolverGroups, in.Input, nil, in.Comment, in.Delay, in.Tags)
 	if err != nil {
 		dbp.Rollback()
 		return nil, err
@@ -260,6 +261,7 @@ type updateTaskIn struct {
 	PublicID         string                 `path:"id,required"`
 	Input            map[string]interface{} `json:"input"`
 	WatcherUsernames []string               `json:"watcher_usernames"`
+	WatcherGroups    []string               `json:"watcher_groups"`
 	Tags             map[string]string      `json:"tags"`
 }
 
@@ -321,6 +323,7 @@ func UpdateTask(c *gin.Context, in *updateTaskIn) (*task.Task, error) {
 
 	t.SetInput(clearInput)
 	t.SetWatcherUsernames(in.WatcherUsernames)
+	t.SetWatcherGroups(in.WatcherGroups)
 
 	// validate read-only tags
 	v, readOnlyTagUpdated := in.Tags[constants.SubtaskTagParentTaskID]

--- a/api/handler/template.go
+++ b/api/handler/template.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/loopfz/gadgeto/zesty"
+
 	"github.com/ovh/utask"
 	"github.com/ovh/utask/models/tasktemplate"
 	"github.com/ovh/utask/pkg/auth"

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -110,7 +110,7 @@ func groupAuthMiddleware(authProvider func(*http.Request) (string, []string, err
 				if errors.IsUnauthorized(err) {
 					c.Header("WWW-Authenticate", `Basic realm="Authorization Required"`)
 				}
-				c.AbortWithError(http.StatusUnauthorized, err)
+				_ = c.AbortWithError(http.StatusUnauthorized, err)
 				return
 			}
 			c.Set(auth.IdentityProviderCtxKey, user)

--- a/api/server.go
+++ b/api/server.go
@@ -55,6 +55,15 @@ func (s *Server) WithAuth(authProvider func(*http.Request) (string, error)) {
 	}
 }
 
+// WithAuthGroup configures the Server's auth group middleware
+// it receives an groupAuthProvider function capable of extracting the caller's groups and identity from an *http.Request
+// the groupAuthProvider function also has discretion to deny authorization for a request by returning an error
+func (s *Server) WithGroupAuth(groupAuthProvider func(*http.Request) (string, []string, error)) {
+	if groupAuthProvider != nil {
+		s.authMiddleware = groupAuthMiddleware(groupAuthProvider)
+	}
+}
+
 // WithCustomMiddlewares sets an array of customized gin middlewares.
 // It helps for init plugins to include these customized middlewares in the api server
 func (s *Server) WithCustomMiddlewares(customMiddlewares ...gin.HandlerFunc) {
@@ -475,11 +484,12 @@ func pingHandler(c *gin.Context) {
 }
 
 type rootOut struct {
-	ApplicationName string `json:"application_name"`
-	UserIsAdmin     bool   `json:"user_is_admin"`
-	Username        string `json:"username"`
-	Version         string `json:"version"`
-	Commit          string `json:"commit"`
+	ApplicationName string   `json:"application_name"`
+	UserIsAdmin     bool     `json:"user_is_admin"`
+	Username        string   `json:"username"`
+	UserGroups      []string `json:"user_groups"`
+	Version         string   `json:"version"`
+	Commit          string   `json:"commit"`
 }
 
 func rootHandler(c *gin.Context) (*rootOut, error) {
@@ -487,6 +497,7 @@ func rootHandler(c *gin.Context) (*rootOut, error) {
 		ApplicationName: utask.AppName(),
 		UserIsAdmin:     auth.IsAdmin(c) == nil,
 		Username:        auth.GetIdentity(c),
+		UserGroups:      auth.GetGroups(c),
 		Version:         utask.Version,
 		Commit:          utask.Commit,
 	}, nil

--- a/api/server.go
+++ b/api/server.go
@@ -493,11 +493,16 @@ type rootOut struct {
 }
 
 func rootHandler(c *gin.Context) (*rootOut, error) {
+	groups := auth.GetGroups(c)
+	if groups == nil {
+		groups = []string{}
+	}
+
 	return &rootOut{
 		ApplicationName: utask.AppName(),
 		UserIsAdmin:     auth.IsAdmin(c) == nil,
 		Username:        auth.GetIdentity(c),
-		UserGroups:      auth.GetGroups(c),
+		UserGroups:      groups,
 		Version:         utask.Version,
 		Commit:          utask.Commit,
 	}, nil

--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -52,7 +52,8 @@ const (
 	envMaintenance = "MAINTENANCE_MODE"
 	envLogsFormat  = "LOGS_FORMAT"
 
-	basicAuthKey = "basic-auth"
+	basicAuthKey  = "basic-auth"
+	groupsAuthKey = "groups-auth"
 )
 
 var (
@@ -140,7 +141,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		server = api.NewServer()
-		server.WithAuth(defaultAuthHandler)
+		server.WithGroupAuth(defaultAuthHandler)
 
 		for _, err := range []error{
 			// register builtin executors
@@ -233,9 +234,25 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 }
 
-// if a map of user passwords is found in configstore
-// use them as basic auth check on incoming requests
-func basicAuthHandler(store *configstore.Store) (func(*http.Request) (string, error), error) {
+// basicAuthHandler handles user and groups authentication.
+//
+// How does it work?
+// If a map of user passwords is found in configstore, use them as basic auth
+// check on incoming requests. The groups of the user are determined from the
+// configuration in configstore. If nothing is found, the zero value of a slice
+// is returned (i.e. `nil`).
+//
+// It is a default implementation which can be overridden by Server.WithAuth or
+// Server.WithGroupAuth functions in api package.
+func basicAuthHandler(store *configstore.Store) (func(*http.Request) (string, []string, error), error) {
+	groupsMap := map[string][]string{}
+	groupsAuthStr, err := configstore.Filter().Slice(groupsAuthKey).Squash().Store(store).MustGetFirstItem().Value()
+	if err == nil {
+		if err = json.Unmarshal([]byte(groupsAuthStr), &groupsMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal utask configuration: %s", err)
+		}
+	}
+
 	authMap := map[string]string{}
 	basicAuthStr, err := configstore.Filter().Slice(basicAuthKey).Squash().Store(store).MustGetFirstItem().Value()
 	if err == nil {
@@ -249,17 +266,18 @@ func basicAuthHandler(store *configstore.Store) (func(*http.Request) (string, er
 		}
 	}
 	if len(authMap) > 0 {
-		return func(r *http.Request) (string, error) {
+		return func(r *http.Request) (string, []string, error) {
 			authHeader := r.Header.Get("Authorization")
 			user, found := authMap[authHeader]
 			if !found {
-				return "", errors.Unauthorizedf("User not found")
+				return "", nil, errors.Unauthorizedf("User not found")
 			}
-			return user, nil
+			return user, groupsMap[user], nil
 		}, nil
 	}
 	// fallback to expecting a username in x-remote-user header
-	return func(r *http.Request) (string, error) {
-		return r.Header.Get("x-remote-user"), nil
+	return func(r *http.Request) (string, []string, error) {
+		user := r.Header.Get("x-remote-user")
+		return user, groupsMap[user], nil
 	}, nil
 }

--- a/config/README.md
+++ b/config/README.md
@@ -41,6 +41,8 @@ postgres://user:pass@db/utask?sslmode=disable
     "application_name": "µTask Foo",
     // admin_usernames is a list of usernames with admin privileges over µTask resources, ie. the ability to view and execute any task, and to hotfix resolutions if a problem arises
     "admin_usernames": ["admin1", "admin2"],
+    // admin_groups is a list of user groups with admin privileges over µTask resources, ie. the ability to view and execute any task, and to hotfix resolutions if a problem arises
+    "admin_groups": ["administrators", "maintainers"],
     // completed_task_expiration is a textual representation of how long a task is kept in DB after its completion
     "completed_task_expiration": "720h", // default == 720h == 30 days
     // notify_config contains a map of named notification configurations, composed of a type and config data,
@@ -184,5 +186,18 @@ postgres://user:pass@db/utask?sslmode=disable
 ```js
 {
     "admin": "1234"
+}
+```
+
+
+### Groups auth
+
+`groups-auth` key is only for development purposes: it is used to declare the users of each group. 
+It consists of a map of group names and slices of usernames.
+
+```json
+{
+    "administrators": ["admin"],
+    "maintainers": ["admin"]
 }
 ```

--- a/db/migration.go
+++ b/db/migration.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	expectedVersion = "v1.18.2-migration007"
+	expectedVersion = "v1.19.0-migration007"
 )
 
 var (

--- a/db/migration.go
+++ b/db/migration.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	expectedVersion = "v1.17.0-migration006"
+	expectedVersion = "v1.18.2-migration007"
 )
 
 var (

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       CFG_DATABASE:       'postgres://user:pass@db/utask?sslmode=disable'
       CFG_UTASK_CFG:      '{"admin_usernames":["admin"],"application_name":"µTask"}'
       CFG_BASIC_AUTH:     '{"admin":"1234","resolver":"3456","regular":"5678"}'
+      CFG_GROUPS_AUTH:    '{"admin":["admins","resolvers"],"resolver": ["resolvers"]}'
       CFG_ENCRYPTION_KEY: '{"identifier":"storage","cipher":"aes-gcm","timestamp":1535627466,"key":"e5f45aef9f072e91f735547be63f3434e6de49695b178e3868b23b0e32269800"}'
     ports:
       - 8081:8081

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       CFG_DATABASE:       'postgres://user:pass@db/utask?sslmode=disable'
       CFG_UTASK_CFG:      '{"admin_usernames":["admin"],"application_name":"µTask"}'
       CFG_BASIC_AUTH:     '{"admin":"1234","resolver":"3456","regular":"5678"}'
-      CFG_GROUPS_AUTH:    '{"admin":["admins","resolvers"],"resolver": ["resolvers"]}'
+      CFG_GROUPS_AUTH:    '{"admins":["admin"],"resolvers":["admin","resolver"]}'
       CFG_ENCRYPTION_KEY: '{"identifier":"storage","cipher":"aes-gcm","timestamp":1535627466,"key":"e5f45aef9f072e91f735547be63f3434e6de49695b178e3868b23b0e32269800"}'
     ports:
       - 8081:8081

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -118,7 +118,7 @@ func createResolution(tmplName string, inputs, resolverInputs map[string]interfa
 	if err != nil {
 		return nil, err
 	}
-	tsk, err := task.Create(dbp, tmpl, "", nil, nil, nil, inputs, nil, nil)
+	tsk, err := task.Create(dbp, tmpl, "", nil, nil, nil, nil, inputs, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -118,7 +118,7 @@ func createResolution(tmplName string, inputs, resolverInputs map[string]interfa
 	if err != nil {
 		return nil, err
 	}
-	tsk, err := task.Create(dbp, tmpl, "", nil, nil, nil, nil, inputs, nil, nil)
+	tsk, err := task.Create(dbp, tmpl, "", nil, nil, nil, nil, nil, inputs, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -118,7 +118,7 @@ func createResolution(tmplName string, inputs, resolverInputs map[string]interfa
 	if err != nil {
 		return nil, err
 	}
-	tsk, err := task.Create(dbp, tmpl, "", nil, nil, inputs, nil, nil)
+	tsk, err := task.Create(dbp, tmpl, "", nil, nil, nil, inputs, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -982,6 +982,14 @@
                 }
             ]
         },
+        "allowed_resolver_groups": {
+            "type": "array",
+            "description": "Groups of people allowed to resolve a task based on this template",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
         "allowed_resolver_usernames": {
             "type": "array",
             "description": "Usernames of people allowed to resolve a task based on this template",

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -492,6 +492,9 @@
                         "resolver_usernames": {
                             "type": "string"
                         },
+                        "resolver_groups": {
+                            "type": "string"
+                        },
                         "watcher_usernames": {
                             "type": "string"
                         },

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -498,6 +498,9 @@
                         "watcher_usernames": {
                             "type": "string"
                         },
+                        "watcher_groups": {
+                            "type": "string"
+                        },
                         "delay": {
                             "type": "string"
                         }

--- a/models/task/task.go
+++ b/models/task/task.go
@@ -75,6 +75,7 @@ type DBModel struct {
 	RequesterUsername string            `json:"requester_username" db:"requester_username"`
 	WatcherUsernames  []string          `json:"watcher_usernames,omitempty" db:"watcher_usernames"`
 	ResolverUsernames []string          `json:"resolver_usernames,omitempty" db:"resolver_usernames"`
+	ResolverGroups    []string          `json:"resolver_groups,omitempty" db:"resolver_groups"`
 	Created           time.Time         `json:"created" db:"created"`
 	State             string            `json:"state" db:"state"`
 	StepsDone         int               `json:"steps_done" db:"steps_done"`
@@ -88,7 +89,7 @@ type DBModel struct {
 }
 
 // Create inserts a new Task in DB
-func Create(dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, reqUsername string, watcherUsernames []string, resolverUsernames []string, input map[string]interface{}, tags map[string]string, b *Batch) (t *Task, err error) {
+func Create(dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, reqUsername string, watcherUsernames []string, resolverUsernames []string, resolverGroups []string, input map[string]interface{}, tags map[string]string, b *Batch) (t *Task, err error) {
 	defer errors.DeferredAnnotatef(&err, "Failed to create new Task")
 
 	t = &Task{
@@ -98,6 +99,7 @@ func Create(dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, reqUsername str
 			RequesterUsername: reqUsername,
 			WatcherUsernames:  watcherUsernames,
 			ResolverUsernames: resolverUsernames,
+			ResolverGroups:    resolverGroups,
 			Created:           now.Get(),
 			LastActivity:      now.Get(),
 			StepsTotal:        len(tt.Steps),
@@ -610,7 +612,7 @@ func (t *Task) ExportTaskInfos(values *values.Values) {
 
 var (
 	tSelector = sqlgenerator.PGsql.Select(
-		`"task".id, "task".public_id, "task".title, "task".id_template, "task".id_batch, "task".requester_username, "task".watcher_usernames, "task".created, "task".state, "task".tags, "task".steps_done, "task".steps_total, "task".crypt_key, "task".encrypted_input, "task".encrypted_result, "task".last_activity, "task".resolver_usernames, "task_template".name as template_name, "task_template".resolver_inputs as resolver_inputs, "resolution".public_id as resolution_public_id, "resolution".last_start as last_start, "resolution".last_stop as last_stop, "resolution".resolver_username as resolver_username, "batch".public_id as batch_public_id`,
+		`"task".id, "task".public_id, "task".title, "task".id_template, "task".id_batch, "task".requester_username, "task".watcher_usernames, "task".created, "task".state, "task".tags, "task".steps_done, "task".steps_total, "task".crypt_key, "task".encrypted_input, "task".encrypted_result, "task".last_activity, "task".resolver_usernames, "task".resolver_groups, "task_template".name as template_name, "task_template".resolver_inputs as resolver_inputs, "resolution".public_id as resolution_public_id, "resolution".last_start as last_start, "resolution".last_stop as last_stop, "resolution".resolver_username as resolver_username, "batch".public_id as batch_public_id`,
 	).From(
 		`"task"`,
 	).Join(

--- a/models/task/task.go
+++ b/models/task/task.go
@@ -79,7 +79,7 @@ type DBModel struct {
 	WatcherGroups     []string          `json:"watcher_groups,omitempty" db:"watcher_groups"`
 	ResolverUsernames []string          `json:"resolver_usernames,omitempty" db:"resolver_usernames"`
 	ResolverGroups    []string          `json:"resolver_groups,omitempty" db:"resolver_groups"`
-	Created           time.Time         `j¬son:"created" db:"created"`
+	Created           time.Time         `json:"created" db:"created"`
 	State             string            `json:"state" db:"state"`
 	StepsDone         int               `json:"steps_done" db:"steps_done"`
 	StepsTotal        int               `json:"steps_total" db:"steps_total"`

--- a/models/tasktemplate/fromdir_test.go
+++ b/models/tasktemplate/fromdir_test.go
@@ -98,7 +98,7 @@ func TestLoadFromDir(t *testing.T) {
 	err = dbp.DB().Insert(&tt)
 	assert.Nil(t, err, "unable to insert new template")
 
-	_, err = task.Create(dbp, &tt, "admin", []string{}, []string{}, []string{}, map[string]interface{}{}, nil, nil)
+	_, err = task.Create(dbp, &tt, "admin", []string{}, []string{}, []string{}, []string{}, map[string]interface{}{}, nil, nil)
 	assert.Nil(t, err, "unable to create task")
 
 	err = tasktemplate.LoadFromDir(dbp, "templates_tests")

--- a/models/tasktemplate/fromdir_test.go
+++ b/models/tasktemplate/fromdir_test.go
@@ -98,7 +98,7 @@ func TestLoadFromDir(t *testing.T) {
 	err = dbp.DB().Insert(&tt)
 	assert.Nil(t, err, "unable to insert new template")
 
-	_, err = task.Create(dbp, &tt, "admin", []string{}, []string{}, []string{}, []string{}, map[string]interface{}{}, nil, nil)
+	_, err = task.Create(dbp, &tt, "admin", []string{}, []string{}, []string{}, []string{}, []string{}, map[string]interface{}{}, nil, nil)
 	assert.Nil(t, err, "unable to create task")
 
 	err = tasktemplate.LoadFromDir(dbp, "templates_tests")

--- a/models/tasktemplate/fromdir_test.go
+++ b/models/tasktemplate/fromdir_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/loopfz/gadgeto/zesty"
 	"github.com/ovh/configstore"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ovh/utask"
 	"github.com/ovh/utask/db"
 	"github.com/ovh/utask/engine/step"
@@ -19,8 +22,6 @@ import (
 	"github.com/ovh/utask/pkg/plugins/builtin/echo"
 	"github.com/ovh/utask/pkg/plugins/builtin/script"
 	pluginsubtask "github.com/ovh/utask/pkg/plugins/builtin/subtask"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -97,7 +98,7 @@ func TestLoadFromDir(t *testing.T) {
 	err = dbp.DB().Insert(&tt)
 	assert.Nil(t, err, "unable to insert new template")
 
-	_, err = task.Create(dbp, &tt, "admin", []string{}, []string{}, map[string]interface{}{}, nil, nil)
+	_, err = task.Create(dbp, &tt, "admin", []string{}, []string{}, []string{}, map[string]interface{}{}, nil, nil)
 	assert.Nil(t, err, "unable to create task")
 
 	err = tasktemplate.LoadFromDir(dbp, "templates_tests")

--- a/models/tasktemplate/template.go
+++ b/models/tasktemplate/template.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/juju/errors"
 	"github.com/loopfz/gadgeto/zesty"
+
 	"github.com/ovh/utask/db/pgjuju"
 	"github.com/ovh/utask/db/sqlgenerator"
 	"github.com/ovh/utask/engine/input"
@@ -457,7 +458,7 @@ func validateVariables(variables []values.Variable) error {
 
 var (
 	ttBasicSelector = sqlgenerator.PGsql.Select(
-		`"task_template".id, "task_template".name, "task_template".description, "task_template".long_description, "task_template".doc_link, "task_template".allowed_resolver_usernames, "task_template".allow_all_resolver_usernames, "task_template".auto_runnable, "task_template".blocked, "task_template".hidden, "task_template".retry_max, "task_template".allow_task_start_over, "task_template".inputs, "task_template".resolver_inputs, "task_template".base_configurations, "task_template".tags`,
+		`"task_template".id, "task_template".name, "task_template".description, "task_template".long_description, "task_template".doc_link, "task_template".allowed_resolver_groups, "task_template".allowed_resolver_usernames, "task_template".allow_all_resolver_usernames, "task_template".auto_runnable, "task_template".blocked, "task_template".hidden, "task_template".retry_max, "task_template".allow_task_start_over, "task_template".inputs, "task_template".resolver_inputs, "task_template".base_configurations, "task_template".tags`,
 	).From(
 		`"task_template"`,
 	).OrderBy(

--- a/models/tasktemplate/template.go
+++ b/models/tasktemplate/template.go
@@ -31,6 +31,7 @@ type TaskTemplate struct {
 	TitleFormat     string                 `json:"title_format,omitempty" db:"title_format"`
 	ResultFormat    map[string]interface{} `json:"result_format,omitempty" db:"result_format"`
 
+	AllowedResolverGroups     []string `json:"allowed_resolver_groups" db:"allowed_resolver_groups"`
 	AllowedResolverUsernames  []string `json:"allowed_resolver_usernames" db:"allowed_resolver_usernames"`
 	AllowAllResolverUsernames bool     `json:"allow_all_resolver_usernames" db:"allow_all_resolver_usernames"`
 	AutoRunnable              bool     `json:"auto_runnable" db:"auto_runnable"`
@@ -53,6 +54,7 @@ func Create(dbp zesty.DBProvider,
 	longDescription,
 	docLink *string,
 	inputs, resolverInputs []input.Input,
+	allowedResolverGroups []string,
 	allowedResolverUsernames []string,
 	allowAllResolverUsernames, autoRunnable bool,
 	steps map[string]*step.Step,
@@ -76,6 +78,7 @@ func Create(dbp zesty.DBProvider,
 		ResolverInputs:            resolverInputs,
 		Variables:                 variables,
 		Tags:                      tags,
+		AllowedResolverGroups:     allowedResolverGroups,
 		AllowedResolverUsernames:  allowedResolverUsernames,
 		AllowAllResolverUsernames: allowAllResolverUsernames,
 		AutoRunnable:              autoRunnable,
@@ -184,6 +187,7 @@ func ListTemplates(dbp zesty.DBProvider, includeHidden bool, pageSize uint64, la
 func (tt *TaskTemplate) Update(dbp zesty.DBProvider,
 	description, longDescription, docLink *string,
 	inputs, resolverInputs []input.Input,
+	allowedResolverGroups []string,
 	allowedResolverUsernames []string,
 	allowAllResolverUsernames, autoRunnable, blocked, hidden *bool,
 	steps map[string]*step.Step,
@@ -208,6 +212,9 @@ func (tt *TaskTemplate) Update(dbp zesty.DBProvider,
 	}
 	if resolverInputs != nil {
 		tt.ResolverInputs = resolverInputs
+	}
+	if allowedResolverGroups != nil {
+		tt.AllowedResolverGroups = allowedResolverGroups
 	}
 	if allowedResolverUsernames != nil {
 		tt.AllowedResolverUsernames = allowedResolverUsernames

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -16,13 +16,22 @@ import (
 // IdentityProviderCtxKey is the key used to store/retrieve identity data from Context
 const IdentityProviderCtxKey = "__identity_provider_key"
 
+// GroupProviderCtxKey is the key used to store/retrieve group data from Context
+const GroupProviderCtxKey = "__group_provider_key"
+
 var (
-	adminUsers []string
+	adminUsers  []string
+	adminGroups []string
 )
 
 // WithIdentity adds identity data to a context
 func WithIdentity(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, IdentityProviderCtxKey, id)
+}
+
+// WithIdentity adds identity data to a context
+func WithGroups(ctx context.Context, groups []string) context.Context {
+	return context.WithValue(ctx, GroupProviderCtxKey, groups)
 }
 
 // Init reads authorization from configstore, bootstraps values
@@ -32,10 +41,11 @@ func Init(store *configstore.Store) error {
 	if err != nil {
 		return err
 	}
-	if len(cfg.AdminUsernames) < 1 {
+	if len(cfg.AdminUsernames) < 1 && len(cfg.AdminGroups) < 1 {
 		return errors.New("Admin user list can't be empty")
 	}
 	adminUsers = cfg.AdminUsernames
+	adminGroups = cfg.AdminGroups
 	return nil
 }
 
@@ -48,13 +58,28 @@ func GetIdentity(ctx context.Context) string {
 	return ""
 }
 
+// GetGroups returns group data stored in context
+func GetGroups(ctx context.Context) []string {
+	groups := ctx.Value(GroupProviderCtxKey)
+	if groups != nil {
+		return groups.([]string)
+	}
+	return []string{}
+}
+
 // IsAdmin asserts that identity data found in context represents an admin user
 func IsAdmin(ctx context.Context) error {
 	id := GetIdentity(ctx)
-	if !utils.ListContainsString(adminUsers, id) {
-		return errors.Forbiddenf("Not an admin user")
+	if utils.ListContainsString(adminUsers, id) {
+		return nil
 	}
-	return nil
+
+	groups := GetGroups(ctx)
+	if utils.HasIntersection(adminGroups, groups) {
+		return nil
+	}
+
+	return errors.Forbiddenf("Not an admin user")
 }
 
 // IsRequester asserts that identity data found in context represents
@@ -78,7 +103,7 @@ func IsWatcher(ctx context.Context, t *task.Task) error {
 }
 
 // IsResolutionManager asserts that identity data found in context is either:
-// - a template owner (allowed_resolver_usernames)
+// - a template owner (allowed_resolver_usernames or allowed_resolver_groups)
 // - a task resolver (resolver_usernames)
 // - this task resolver (resolver_username)
 func IsResolutionManager(ctx context.Context, tt *tasktemplate.TaskTemplate, t *task.Task, r *resolution.Resolution) error {
@@ -103,7 +128,9 @@ func IsResolutionManager(ctx context.Context, tt *tasktemplate.TaskTemplate, t *
 	return errors.Forbiddenf("User not authorized on this resolution")
 }
 
-// IsTemplateOwner asserts that identity data found in context is a template allowed_resolver_usernames
+// IsTemplateOwner asserts that:
+// - identity data found in context is a template allowed_resolver_usernames
+// - or group data found in context is a template allowed_resolver_groups
 func IsTemplateOwner(ctx context.Context, tt *tasktemplate.TaskTemplate) error {
 	id := GetIdentity(ctx)
 
@@ -112,6 +139,11 @@ func IsTemplateOwner(ctx context.Context, tt *tasktemplate.TaskTemplate) error {
 	}
 
 	if utils.ListContainsString(tt.AllowedResolverUsernames, id) {
+		return nil
+	}
+
+	groups := GetGroups(ctx)
+	if utils.HasIntersection(tt.AllowedResolverGroups, groups) {
 		return nil
 	}
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -104,7 +104,7 @@ func IsWatcher(ctx context.Context, t *task.Task) error {
 
 // IsResolutionManager asserts that identity data found in context is either:
 // - a template owner (allowed_resolver_usernames or allowed_resolver_groups)
-// - a task resolver (resolver_usernames)
+// - a task resolver (resolver_usernames or resolver_groups)
 // - this task resolver (resolver_username)
 func IsResolutionManager(ctx context.Context, tt *tasktemplate.TaskTemplate, t *task.Task, r *resolution.Resolution) error {
 	id := GetIdentity(ctx)
@@ -122,6 +122,11 @@ func IsResolutionManager(ctx context.Context, tt *tasktemplate.TaskTemplate, t *
 	}
 
 	if r != nil && r.ResolverUsername == id {
+		return nil
+	}
+
+	groups := GetGroups(ctx)
+	if utils.HasIntersection(t.ResolverGroups, groups) {
 		return nil
 	}
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -96,10 +96,16 @@ func IsRequester(ctx context.Context, t *task.Task) error {
 // a watcher of the given task
 func IsWatcher(ctx context.Context, t *task.Task) error {
 	id := GetIdentity(ctx)
-	if !utils.ListContainsString(t.WatcherUsernames, id) {
-		return errors.Forbiddenf("User is not watcher of this task")
+	if utils.ListContainsString(t.WatcherUsernames, id) {
+		return nil
 	}
-	return nil
+
+	groups := GetGroups(ctx)
+	if utils.HasIntersection(t.WatcherGroups, groups) {
+		return nil
+	}
+
+	return errors.Forbiddenf("User is not watcher of this task")
 }
 
 // IsResolutionManager asserts that identity data found in context is either:

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -26,12 +26,12 @@ var (
 
 // WithIdentity adds identity data to a context
 func WithIdentity(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, IdentityProviderCtxKey, id)
+	return context.WithValue(ctx, IdentityProviderCtxKey, id) // nolint
 }
 
 // WithIdentity adds identity data to a context
 func WithGroups(ctx context.Context, groups []string) context.Context {
-	return context.WithValue(ctx, GroupProviderCtxKey, groups)
+	return context.WithValue(ctx, GroupProviderCtxKey, groups) // nolint
 }
 
 // Init reads authorization from configstore, bootstraps values

--- a/pkg/plugins/builtin/subtask/README.md
+++ b/pkg/plugins/builtin/subtask/README.md
@@ -12,6 +12,7 @@ fully `DONE`.
 | `resolver_usernames` | a string containing a JSON array of additional resolver users for the subtask                                     |
 | `resolver_groups`    | a string containing a JSON array of additional resolver groups for the subtask                                    |
 | `watcher_usernames`  | a string containing a JSON array of additional watcher users for the subtask                                      |
+| `watcher_groups`     | a string containing a JSON array of additional watcher groups for the subtask                                     |
 | `delay`              | a duration indicating if subtask execution needs to be delayed, expects Golang time.Duration format (5s, 1m, ...) |
 
 ## Example
@@ -31,6 +32,7 @@ action:
     resolver_usernames: '["authorizedUser"]'
     resolver_groups: '["authorizedGroup"]'
     watcher_usernames: '["authorizedUser"]'
+    watcher_groups: '["authorizedGroup"]'
     delay: 10m
 ```
 

--- a/pkg/plugins/builtin/subtask/README.md
+++ b/pkg/plugins/builtin/subtask/README.md
@@ -1,14 +1,16 @@
 # `subtask` Plugin
 
-This plugin creates a new task. A step based on this type of action will remain incomplete until the subtask is fully `DONE`.
+This plugin creates a new task. A step based on this type of action will remain incomplete until the subtask is
+fully `DONE`.
 
 ## Configuration
 
 | Fields               | Description                                                                                                       |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+|----------------------|-------------------------------------------------------------------------------------------------------------------|
 | `template`           | the name of a task template, as accepted through µTask's  API                                                     |
 | `input`              | a map of named values, as accepted on µTask's API                                                                 |
 | `resolver_usernames` | a string containing a JSON array of additional resolver users for the subtask                                     |
+| `resolver_groups`    | a string containing a JSON array of additional resolver groups for the subtask                                    |
 | `watcher_usernames`  | a string containing a JSON array of additional watcher users for the subtask                                      |
 | `delay`              | a duration indicating if subtask execution needs to be delayed, expects Golang time.Duration format (5s, 1m, ...) |
 
@@ -27,6 +29,7 @@ action:
       foo: bar
     # optionally, a list of users which are authorized to resolve this specific task
     resolver_usernames: '["authorizedUser"]'
+    resolver_groups: '["authorizedGroup"]'
     watcher_usernames: '["authorizedUser"]'
     delay: 10m
 ```
@@ -40,7 +43,7 @@ None.
 ### Output
 
 | Name                 | Description                               |
-| -------------------- | ----------------------------------------- |
+|----------------------|-------------------------------------------|
 | `id`                 | The public identifier of the task         |
 | `state`              | The state of the task                     |
 | `result`             | The result of the task                    |

--- a/pkg/plugins/builtin/subtask/subtask.go
+++ b/pkg/plugins/builtin/subtask/subtask.go
@@ -36,6 +36,7 @@ type SubtaskConfig struct {
 	ResolverUsernames string                 `json:"resolver_usernames"`
 	ResolverGroups    string                 `json:"resolver_groups"`
 	WatcherUsernames  string                 `json:"watcher_usernames"`
+	WatcherGroups     string                 `json:"watcher_groups"`
 	Delay             *string                `json:"delay"`
 	Tags              map[string]string      `json:"tags"`
 }
@@ -114,7 +115,7 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 			return nil, nil, err
 		}
 
-		var resolverUsernames, resolverGroups, watcherUsernames []string
+		var resolverUsernames, resolverGroups, watcherUsernames, watcherGroups []string
 		if cfg.ResolverUsernames != "" {
 			resolverUsernames, err = utils.ConvertJSONRowToSlice(cfg.ResolverUsernames)
 			if err != nil {
@@ -133,6 +134,12 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 				return nil, nil, fmt.Errorf("can't convert JSON to row slice: %s", err)
 			}
 		}
+		if cfg.WatcherGroups != "" {
+			watcherGroups, err = utils.ConvertJSONRowToSlice(cfg.WatcherGroups)
+			if err != nil {
+				return nil, nil, fmt.Errorf("can't convert JSON to row slice: %s", err)
+			}
+		}
 
 		// TODO inherit watchers from parent task
 		ctx := auth.WithIdentity(context.Background(), stepContext.RequesterUsername)
@@ -140,7 +147,7 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 			cfg.Tags = map[string]string{}
 		}
 		cfg.Tags[constants.SubtaskTagParentTaskID] = stepContext.ParentTaskID
-		t, err = taskutils.CreateTask(ctx, dbp, tt, watcherUsernames, resolverUsernames, resolverGroups, cfg.Input, nil, "Auto created subtask, parent task "+stepContext.ParentTaskID, cfg.Delay, cfg.Tags)
+		t, err = taskutils.CreateTask(ctx, dbp, tt, watcherUsernames, watcherGroups, resolverUsernames, resolverGroups, cfg.Input, nil, "Auto created subtask, parent task "+stepContext.ParentTaskID, cfg.Delay, cfg.Tags)
 		if err != nil {
 			dbp.Rollback()
 			return nil, nil, err

--- a/pkg/plugins/builtin/subtask/subtask.go
+++ b/pkg/plugins/builtin/subtask/subtask.go
@@ -148,7 +148,7 @@ func exec(stepName string, config interface{}, ctx interface{}) (interface{}, in
 
 		// TODO inherit watchers from parent task
 		ctx := auth.WithIdentity(context.Background(), stepContext.RequesterUsername)
-		ctx = auth.WithGroups(context.Background(), requesterGroups)
+		ctx = auth.WithGroups(ctx, requesterGroups)
 		if cfg.Tags == nil {
 			cfg.Tags = map[string]string{}
 		}

--- a/pkg/taskutils/taskutils.go
+++ b/pkg/taskutils/taskutils.go
@@ -16,12 +16,13 @@ import (
 // CreateTask creates a task with the given inputs, and creates a resolution if autorunnable
 func CreateTask(c context.Context, dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, watcherUsernames []string, watcherGroups []string, resolverUsernames []string, resolverGroups []string, input map[string]interface{}, b *task.Batch, comment string, delay *string, tags map[string]string) (*task.Task, error) {
 	reqUsername := auth.GetIdentity(c)
+	reqGroups := auth.GetGroups(c)
 
 	if tt.Blocked {
 		return nil, errors.NewNotValid(nil, "Template not available (blocked)")
 	}
 
-	t, err := task.Create(dbp, tt, reqUsername, watcherUsernames, watcherGroups, resolverUsernames, resolverGroups, input, tags, b)
+	t, err := task.Create(dbp, tt, reqUsername, reqGroups, watcherUsernames, watcherGroups, resolverUsernames, resolverGroups, input, tags, b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/taskutils/taskutils.go
+++ b/pkg/taskutils/taskutils.go
@@ -14,14 +14,14 @@ import (
 )
 
 // CreateTask creates a task with the given inputs, and creates a resolution if autorunnable
-func CreateTask(c context.Context, dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, watcherUsernames []string, resolverUsernames []string, input map[string]interface{}, b *task.Batch, comment string, delay *string, tags map[string]string) (*task.Task, error) {
+func CreateTask(c context.Context, dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, watcherUsernames []string, resolverUsernames []string, resolverGroups []string, input map[string]interface{}, b *task.Batch, comment string, delay *string, tags map[string]string) (*task.Task, error) {
 	reqUsername := auth.GetIdentity(c)
 
 	if tt.Blocked {
 		return nil, errors.NewNotValid(nil, "Template not available (blocked)")
 	}
 
-	t, err := task.Create(dbp, tt, reqUsername, watcherUsernames, resolverUsernames, input, tags, b)
+	t, err := task.Create(dbp, tt, reqUsername, watcherUsernames, resolverUsernames, resolverGroups, input, tags, b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/taskutils/taskutils.go
+++ b/pkg/taskutils/taskutils.go
@@ -14,14 +14,14 @@ import (
 )
 
 // CreateTask creates a task with the given inputs, and creates a resolution if autorunnable
-func CreateTask(c context.Context, dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, watcherUsernames []string, resolverUsernames []string, resolverGroups []string, input map[string]interface{}, b *task.Batch, comment string, delay *string, tags map[string]string) (*task.Task, error) {
+func CreateTask(c context.Context, dbp zesty.DBProvider, tt *tasktemplate.TaskTemplate, watcherUsernames []string, watcherGroups []string, resolverUsernames []string, resolverGroups []string, input map[string]interface{}, b *task.Batch, comment string, delay *string, tags map[string]string) (*task.Task, error) {
 	reqUsername := auth.GetIdentity(c)
 
 	if tt.Blocked {
 		return nil, errors.NewNotValid(nil, "Template not available (blocked)")
 	}
 
-	t, err := task.Create(dbp, tt, reqUsername, watcherUsernames, resolverUsernames, resolverGroups, input, tags, b)
+	t, err := task.Create(dbp, tt, reqUsername, watcherUsernames, watcherGroups, resolverUsernames, resolverGroups, input, tags, b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -62,6 +62,16 @@ func ListContainsString(list []string, item string) bool {
 	return false
 }
 
+// HasIntersection asserts that the given lists have an intersection (a common item) between them
+func HasIntersection(referenceList []string, items []string) bool {
+	for _, i := range items {
+		if ListContainsString(referenceList, i) {
+			return true
+		}
+	}
+	return false
+}
+
 // AppendUniq does the same thing than append but insure we have only 1 iteam of each
 func AppendUniq(list []string, items ...string) []string {
 	for _, item := range items {

--- a/sql/migrations/006_allowed_resolver_groups.sql
+++ b/sql/migrations/006_allowed_resolver_groups.sql
@@ -1,7 +1,0 @@
--- +migrate Up
-
-ALTER TABLE "task_template" ADD COLUMN "allowed_resolver_groups" JSONB NOT NULL DEFAULT '[]';
-
--- +migrate Down
-
-ALTER TABLE "task_template" DROP COLUMN "allowed_resolver_groups";

--- a/sql/migrations/006_allowed_resolver_groups.sql
+++ b/sql/migrations/006_allowed_resolver_groups.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+ALTER TABLE "task_template" ADD COLUMN "allowed_resolver_groups" JSONB NOT NULL DEFAULT '[]';
+
+-- +migrate Down
+
+ALTER TABLE "task_template" DROP COLUMN "allowed_resolver_groups";

--- a/sql/migrations/007_allowed_resolver_groups.sql
+++ b/sql/migrations/007_allowed_resolver_groups.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+
+ALTER TABLE "task_template" ADD COLUMN "allowed_resolver_groups" JSONB NOT NULL DEFAULT '[]';
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.18.2-migration007');
+
+-- +migrate Down
+
+ALTER TABLE "task_template" DROP COLUMN "allowed_resolver_groups";
+
+UPDATE "utask_sql_migrations" SET "current_migration_applied" = 'v1.18.2-migration007';

--- a/sql/migrations/007_user_groups.sql
+++ b/sql/migrations/007_user_groups.sql
@@ -7,7 +7,7 @@ ALTER TABLE "task" ADD COLUMN "watcher_groups" JSONB NOT NULL DEFAULT 'null';
 CREATE INDEX "task_resolver_groups_idx" ON "task" USING gin (resolver_groups jsonb_path_ops);
 CREATE INDEX "task_watcher_groups_idx" ON "task" USING gin (watcher_groups jsonb_path_ops);
 
-INSERT INTO "utask_sql_migrations" VALUES ('v1.18.2-migration007');
+INSERT INTO "utask_sql_migrations" VALUES ('v1.19.0-migration007');
 
 -- +migrate Down
 
@@ -17,4 +17,4 @@ ALTER TABLE "task" DROP COLUMN "resolver_groups", "watcher_groups";
 DROP INDEX "task_resolver_groups_idx";
 DROP INDEX "task_watcher_groups_idx";
 
-DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.18.2-migration007';
+DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.19.0-migration007';

--- a/sql/migrations/007_user_groups.sql
+++ b/sql/migrations/007_user_groups.sql
@@ -3,6 +3,7 @@
 ALTER TABLE "task_template" ADD COLUMN "allowed_resolver_groups" JSONB NOT NULL DEFAULT '[]';
 ALTER TABLE "task" ADD COLUMN "resolver_groups" JSONB NOT NULL DEFAULT 'null';
 ALTER TABLE "task" ADD COLUMN "watcher_groups" JSONB NOT NULL DEFAULT 'null';
+ALTER TABLE "task" ADD COLUMN "requester_groups" JSONB NOT NULL DEFAULT 'null';
 
 CREATE INDEX "task_resolver_groups_idx" ON "task" USING gin (resolver_groups jsonb_path_ops);
 CREATE INDEX "task_watcher_groups_idx" ON "task" USING gin (watcher_groups jsonb_path_ops);
@@ -14,5 +15,6 @@ INSERT INTO "utask_sql_migrations" VALUES ('v1.19.0-migration007');
 ALTER TABLE "task_template" DROP COLUMN "allowed_resolver_groups";
 ALTER TABLE "task" DROP COLUMN "resolver_groups";
 ALTER TABLE "task" DROP COLUMN "watcher_groups";
+ALTER TABLE "task" DROP COLUMN "requester_groups";
 
 DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.19.0-migration007';

--- a/sql/migrations/007_user_groups.sql
+++ b/sql/migrations/007_user_groups.sql
@@ -12,9 +12,7 @@ INSERT INTO "utask_sql_migrations" VALUES ('v1.19.0-migration007');
 -- +migrate Down
 
 ALTER TABLE "task_template" DROP COLUMN "allowed_resolver_groups";
-ALTER TABLE "task" DROP COLUMN "resolver_groups", "watcher_groups";
-
-DROP INDEX "task_resolver_groups_idx";
-DROP INDEX "task_watcher_groups_idx";
+ALTER TABLE "task" DROP COLUMN "resolver_groups";
+ALTER TABLE "task" DROP COLUMN "watcher_groups";
 
 DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.19.0-migration007';

--- a/sql/migrations/007_user_groups.sql
+++ b/sql/migrations/007_user_groups.sql
@@ -5,8 +5,8 @@ ALTER TABLE "task" ADD COLUMN "resolver_groups" JSONB NOT NULL DEFAULT 'null';
 ALTER TABLE "task" ADD COLUMN "watcher_groups" JSONB NOT NULL DEFAULT 'null';
 ALTER TABLE "task" ADD COLUMN "requester_groups" JSONB NOT NULL DEFAULT 'null';
 
-CREATE INDEX "task_resolver_groups_idx" ON "task" USING gin (resolver_groups jsonb_path_ops);
-CREATE INDEX "task_watcher_groups_idx" ON "task" USING gin (watcher_groups jsonb_path_ops);
+CREATE INDEX "task_resolver_groups_idx" ON "task" USING gin (resolver_groups);
+CREATE INDEX "task_watcher_groups_idx" ON "task" USING gin (watcher_groups);
 
 INSERT INTO "utask_sql_migrations" VALUES ('v1.19.0-migration007');
 

--- a/sql/migrations/007_user_groups.sql
+++ b/sql/migrations/007_user_groups.sql
@@ -1,11 +1,17 @@
 -- +migrate Up
 
 ALTER TABLE "task_template" ADD COLUMN "allowed_resolver_groups" JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE "task" ADD COLUMN "resolver_groups" JSONB NOT NULL DEFAULT 'null';
+
+CREATE INDEX "task_resolver_groups_idx" ON "task" USING gin (resolver_groups jsonb_path_ops);
 
 INSERT INTO "utask_sql_migrations" VALUES ('v1.18.2-migration007');
 
 -- +migrate Down
 
 ALTER TABLE "task_template" DROP COLUMN "allowed_resolver_groups";
+ALTER TABLE "task" DROP COLUMN "resolver_groups";
+
+DROP INDEX "task_resolver_groups_idx";
 
 UPDATE "utask_sql_migrations" SET "current_migration_applied" = 'v1.18.2-migration007';

--- a/sql/migrations/007_user_groups.sql
+++ b/sql/migrations/007_user_groups.sql
@@ -2,16 +2,19 @@
 
 ALTER TABLE "task_template" ADD COLUMN "allowed_resolver_groups" JSONB NOT NULL DEFAULT '[]';
 ALTER TABLE "task" ADD COLUMN "resolver_groups" JSONB NOT NULL DEFAULT 'null';
+ALTER TABLE "task" ADD COLUMN "watcher_groups" JSONB NOT NULL DEFAULT 'null';
 
 CREATE INDEX "task_resolver_groups_idx" ON "task" USING gin (resolver_groups jsonb_path_ops);
+CREATE INDEX "task_watcher_groups_idx" ON "task" USING gin (watcher_groups jsonb_path_ops);
 
 INSERT INTO "utask_sql_migrations" VALUES ('v1.18.2-migration007');
 
 -- +migrate Down
 
 ALTER TABLE "task_template" DROP COLUMN "allowed_resolver_groups";
-ALTER TABLE "task" DROP COLUMN "resolver_groups";
+ALTER TABLE "task" DROP COLUMN "resolver_groups", "watcher_groups";
 
 DROP INDEX "task_resolver_groups_idx";
+DROP INDEX "task_watcher_groups_idx";
 
-UPDATE "utask_sql_migrations" SET "current_migration_applied" = 'v1.18.2-migration007';
+DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.18.2-migration007';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE "task_template" (
     resolver_inputs JSONB NOT NULL,
     steps JSONB NOT NULL,
     variables JSONB NOT NULL DEFAULT 'null',
+    allowed_resolver_groups JSONB NOT NULL DEFAULT '[]',
     allowed_resolver_usernames JSONB NOT NULL DEFAULT '[]',
     allow_all_resolver_usernames BOOL NOT NULL DEFAULT false,
     auto_runnable BOOL NOT NULL DEFAULT false,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -112,6 +112,6 @@ CREATE TABLE "utask_sql_migrations" (
     current_migration_applied TEXT PRIMARY KEY
 );
 
-INSERT INTO "utask_sql_migrations" VALUES ('v1.17.0-migration006');
+INSERT INTO "utask_sql_migrations" VALUES ('v1.18.2-migration007');
 
 END;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -116,6 +116,6 @@ CREATE TABLE "utask_sql_migrations" (
     current_migration_applied TEXT PRIMARY KEY
 );
 
-INSERT INTO "utask_sql_migrations" VALUES ('v1.18.2-migration007');
+INSERT INTO "utask_sql_migrations" VALUES ('v1.19.0-migration007');
 
 END;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE "task" (
     requester_username TEXT,
     watcher_usernames JSONB NOT NULL DEFAULT 'null',
     resolver_usernames JSONB NOT NULL DEFAULT 'null',
+    "resolver_groups" JSONB NOT NULL DEFAULT 'null',
     created TIMESTAMP with time zone DEFAULT now() NOT NULL,
     last_activity TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     state TEXT NOT NULL,
@@ -66,6 +67,7 @@ CREATE INDEX ON "task"(last_activity DESC);
 -- https://www.postgresql.org/docs/9.4/datatype-json.html
 CREATE INDEX ON "task" USING gin (watcher_usernames jsonb_path_ops);
 CREATE INDEX ON "task" USING gin (resolver_usernames jsonb_path_ops);
+CREATE INDEX ON "task" USING gin (resolver_groups jsonb_path_ops);
 CREATE INDEX ON "task" USING gin (tags jsonb_path_ops);
 
 CREATE TABLE "task_comment" (

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE "task" (
     id_batch BIGINT REFERENCES "batch"(id),
     title TEXT NOT NULL,
     requester_username TEXT,
+    requester_groups JSONB NOT NULL DEFAULT 'null',
     watcher_usernames JSONB NOT NULL DEFAULT 'null',
     watcher_groups JSONB NOT NULL DEFAULT 'null',
     resolver_usernames JSONB NOT NULL DEFAULT 'null',

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -45,8 +45,9 @@ CREATE TABLE "task" (
     title TEXT NOT NULL,
     requester_username TEXT,
     watcher_usernames JSONB NOT NULL DEFAULT 'null',
+    watcher_groups JSONB NOT NULL DEFAULT 'null',
     resolver_usernames JSONB NOT NULL DEFAULT 'null',
-    "resolver_groups" JSONB NOT NULL DEFAULT 'null',
+    resolver_groups JSONB NOT NULL DEFAULT 'null',
     created TIMESTAMP with time zone DEFAULT now() NOT NULL,
     last_activity TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     state TEXT NOT NULL,
@@ -66,6 +67,7 @@ CREATE INDEX ON "task"(last_activity DESC);
 -- See section 8.14.4 relative to jsonb indexing:
 -- https://www.postgresql.org/docs/9.4/datatype-json.html
 CREATE INDEX ON "task" USING gin (watcher_usernames jsonb_path_ops);
+CREATE INDEX ON "task" USING gin (watcher_groups jsonb_path_ops);
 CREATE INDEX ON "task" USING gin (resolver_usernames jsonb_path_ops);
 CREATE INDEX ON "task" USING gin (resolver_groups jsonb_path_ops);
 CREATE INDEX ON "task" USING gin (tags jsonb_path_ops);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -68,9 +68,9 @@ CREATE INDEX ON "task"(last_activity DESC);
 -- See section 8.14.4 relative to jsonb indexing:
 -- https://www.postgresql.org/docs/9.4/datatype-json.html
 CREATE INDEX ON "task" USING gin (watcher_usernames jsonb_path_ops);
-CREATE INDEX ON "task" USING gin (watcher_groups jsonb_path_ops);
+CREATE INDEX ON "task" USING gin (watcher_groups);
 CREATE INDEX ON "task" USING gin (resolver_usernames jsonb_path_ops);
-CREATE INDEX ON "task" USING gin (resolver_groups jsonb_path_ops);
+CREATE INDEX ON "task" USING gin (resolver_groups);
 CREATE INDEX ON "task" USING gin (tags jsonb_path_ops);
 
 CREATE TABLE "task_comment" (

--- a/ui/dashboard/projects/utask-lib/src/lib/@models/meta.model.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@models/meta.model.ts
@@ -2,7 +2,8 @@ export default class Meta {
     application_name: string;
     user_is_admin: boolean;
     username: string;
-    
+    user_groups: string[];
+
     public constructor(init?: Partial<Meta>) {
         Object.assign(this, init);
     }

--- a/ui/dashboard/projects/utask-lib/src/lib/@models/task.model.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@models/task.model.ts
@@ -73,6 +73,7 @@ export default class Task {
     last_stop: Date;
     requester_username: string;
     resolver_usernames: string[];
+    resolver_groups: string[];
     resolution: string;
     resolver_username: string;
     result: any;

--- a/ui/dashboard/projects/utask-lib/src/lib/@models/task.model.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@models/task.model.ts
@@ -83,6 +83,7 @@ export default class Task {
     template_name: string;
     title: string;
     watcher_usernames: string[];
+    watcher_groups: string[];
     tags: { [key: string]: string };
     resolver_inputs: ResolverInput[];
 

--- a/ui/dashboard/projects/utask-lib/src/lib/@models/template.model.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@models/template.model.ts
@@ -6,6 +6,7 @@ export default class Template {
     auto_runnable: boolean;
     allow_all_resolver_usernames: boolean;
     allowed_resolver_usernames: string[];
+    allowed_resolver_groups: string[];
     doc_link: string;
     inputs: any[];
     resolver_inputs: any[];

--- a/ui/dashboard/projects/utask-lib/src/lib/@routes/new/new.component.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@routes/new/new.component.ts
@@ -33,7 +33,8 @@ export class NewComponent implements OnInit {
   ngOnInit() {
     this.validateForm = this._fb.group({
       template: [null, [Validators.required]],
-      watchers: [null, []]
+      watchers: [null, []],
+      watcher_groups: [null, []]
     });
 
     this.templates = this._activatedRoute.snapshot.data.templates.sort((a, b) => {
@@ -49,7 +50,10 @@ export class NewComponent implements OnInit {
             template,
             watchers: values.watcher_usernames ?
               (isArray(values.watcher_usernames) ? values.watcher_usernames : [values.watcher_usernames])
-              : []
+              : [],
+            watcher_groups: values.watcher_groups ?
+                (isArray(values.watcher_groups) ? values.watcher_groups : [values.watcher_groups])
+                : []
           };
           (template.inputs ?? []).forEach(input => {
             if (input.collection && !isArray(values[input.name])) {
@@ -94,6 +98,7 @@ export class NewComponent implements OnInit {
     item.template_name = values.template.name;
     item.input = InputsFormComponent.getInputs(values);
     item.watcher_usernames = values.watchers ? values.watchers : [];
+    item.watcher_groups = values.watcher_groups ? values.watcher_groups : [];
     return item;
   }
 
@@ -128,7 +133,8 @@ export class NewComponent implements OnInit {
 
     const queryParams = {
       template_name: item.template_name,
-      watcher_usernames: item.watcher_usernames
+      watcher_usernames: item.watcher_usernames,
+      watcher_groups: item.watcher_groups
     };
 
     Object.keys(item.input)

--- a/ui/dashboard/projects/utask-lib/src/lib/@routes/new/new.html
+++ b/ui/dashboard/projects/utask-lib/src/lib/@routes/new/new.html
@@ -43,6 +43,15 @@
                 </nz-form-control>
             </nz-form-item>
             <nz-form-item>
+                <nz-form-label nzFor="watcher_groups">
+                    Watcher groups
+                </nz-form-label>
+                <nz-form-control nzErrorTip="Please set a valid value for watcher groups!">
+                    <nz-select formControlName="watcher_groups" nzMode="tags" nzPlaceHolder="Groups">
+                    </nz-select>
+                </nz-form-control>
+            </nz-form-item>
+            <nz-form-item>
                 <nz-form-control>
                     <button type="submit" nz-button [disabled]="!validateForm.valid" [nzLoading]="loaders.submit"
                         nzType="primary">Submit</button>

--- a/ui/dashboard/projects/utask-lib/src/lib/@services/api.service.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@services/api.service.ts
@@ -26,12 +26,14 @@ export class NewTask {
     tags: { [key: string]: string };
     template_name: string;
     watcher_usernames: string[];
+    watcher_groups: string[];
 }
 
 export class UpdatedTask {
     input: any;
     tags: { [key: string]: string };
     watcher_usernames: string[];
+    watcher_groups: string[];
 }
 
 export class ApiServiceComment {

--- a/ui/dashboard/projects/utask-lib/src/lib/@services/request.service.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@services/request.service.ts
@@ -40,7 +40,8 @@ export class RequestService {
                 meta.user_is_admin ||
                 (template.allowed_resolver_usernames ?? []).indexOf(meta.username) > -1 ||
                 (template.allowed_resolver_groups ?? []).some(group => (meta.user_groups ?? []).includes(group)) ||
-                (task.resolver_usernames ?? []).indexOf(meta.username) > -1
+                (task.resolver_usernames ?? []).indexOf(meta.username) > -1 ||
+                (task.resolver_groups ?? []).some(group => (meta.user_groups ?? []).includes(group))
             );
     }
 }

--- a/ui/dashboard/projects/utask-lib/src/lib/@services/request.service.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@services/request.service.ts
@@ -39,6 +39,7 @@ export class RequestService {
             (
                 meta.user_is_admin ||
                 (template.allowed_resolver_usernames ?? []).indexOf(meta.username) > -1 ||
+                (template.allowed_resolver_groups ?? []).some(group => (meta.user_groups ?? []).includes(group)) ||
                 (task.resolver_usernames ?? []).indexOf(meta.username) > -1
             );
     }

--- a/utask.go
+++ b/utask.go
@@ -95,6 +95,9 @@ const (
 	NotificationStrategyAlways = "always"
 	// NotificationStrategyFailureOnly corresponds to the mode where notifications will only be sent if the state is BLOCKED
 	NotificationStrategyFailureOnly = "failure_only"
+
+	// GroupsSeparator corresponds to the separator used to break a string into a list of groups and vice versa.
+	GroupsSeparator = ","
 )
 
 // Cfg holds global configuration data

--- a/utask.go
+++ b/utask.go
@@ -101,6 +101,7 @@ const (
 type Cfg struct {
 	ApplicationName                            string                   `json:"application_name"`
 	AdminUsernames                             []string                 `json:"admin_usernames"`
+	AdminGroups                                []string                 `json:"admin_groups"`
 	CompletedTaskExpiration                    string                   `json:"completed_task_expiration"`
 	NotifyConfig                               map[string]NotifyBackend `json:"notify_config"`
 	NotifyActions                              NotifyActions            `json:"notify_actions"`


### PR DESCRIPTION
* **What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

* **What is the new behavior ?**

This PR introduces the group support to handle permissions access from an identity provider. The goal is to able be to give rights (resolve tasks, be an administrator) to groups. All users of these groups will inherit the rights granted.

New fields has been added : 
- `allowed_resolvers_groups` on template : to authorize the users of these groups to resolve the tasks
- `admin_groups` on configuration : to consider the users of these groups to be administrator

A new method exposed by `service.Server` :

- `WithGroupAuth(groupAuthProvider func(*http.Request) (string, []string, error))`, which has the same use as `WithGroupAuth` *(provide a custom source of authentication and authorization)*. The difference is that the method returns the user (`string`) and his groups (`[]string`).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking change
