### PR TITLE
fix: go-staticcheck: break loop were not positionned at the correct level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest AS js-builder
+FROM node:16 AS js-builder
 
 RUN npm install -g @angular/cli
 COPY ./ui /home/node/ui
@@ -11,7 +11,7 @@ RUN BASEHREF=___UTASK_DASHBOARD_BASEHREF___ PREFIX_API_BASE_URL=___UTASK_DASHBOA
 WORKDIR /home/node/ui/editor
 RUN BASEHREF=___UTASK_EDITOR_BASEHREF___ SENTRY_DSN=___UTASK_DASHBOARD_SENTRY_DSN___ make build-prod
 
-FROM golang:1.16-buster
+FROM golang:1.17-buster
 
 COPY .  /go/src/github.com/ovh/utask
 WORKDIR /go/src/github.com/ovh/utask

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -385,6 +385,7 @@ func resolve(dbp zesty.DBProvider, res *resolution.Resolution, t *task.Task, sm 
 
 	expectedMessages := runAvailableSteps(dbp, map[string]bool{}, res, t, stepChan, executedSteps, []string{}, wg, debugLogger)
 
+forLoop:
 	for expectedMessages > 0 {
 		debugLogger.Debugf("Engine: resolve() %s loop, %d expected steps", res.PublicID, expectedMessages)
 		select {
@@ -462,7 +463,7 @@ func resolve(dbp zesty.DBProvider, res *resolution.Resolution, t *task.Task, sm 
 		case <-gracePeriodEnd:
 			// shutting down, time is up: exit the loop no matter how many steps might be pending
 			expectedMessages = 0
-			break
+			break forLoop
 		}
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
At utask interruption, we were not processing correctly the break out of the loop, causing utask not to exit instantly.


* **What is the new behavior (if this is a feature change)?**
utask is now exiting when it should.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
