### PR TITLE
fix: rbac: update of a step state is reserved to template owners only

### DIFF
--- a/api/handler/resolution.go
+++ b/api/handler/resolution.go
@@ -807,7 +807,7 @@ type updateResolutionStepStateIn struct {
 }
 
 // UpdateResolutionStepState allows the edition of a step state.
-// Can only be called when the resolution is in state PAUSED, and by a resolution manager.
+// Can only be called when the resolution is in state PAUSED, and by the template owners.
 func UpdateResolutionStepState(c *gin.Context, in *updateResolutionStepStateIn) error {
 	metadata.AddActionMetadata(c, metadata.ResolutionID, in.PublicID)
 	metadata.AddActionMetadata(c, metadata.StepName, in.StepName)
@@ -854,7 +854,7 @@ func UpdateResolutionStepState(c *gin.Context, in *updateResolutionStepStateIn) 
 	metadata.AddActionMetadata(c, metadata.TemplateName, tt.Name)
 
 	admin := auth.IsAdmin(c) == nil
-	resolutionManager := auth.IsResolutionManager(c, tt, t, r) == nil
+	resolutionManager := auth.IsTemplateOwner(c, tt) == nil
 
 	if !admin && !resolutionManager {
 		dbp.Rollback()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Previously, edition of the step state was allowed to resolvers. But
resolvers are regular users, that have the right to resolve the task,
they are not aware of the behaviour of the template.


* **What is the new behavior (if this is a feature change)?**
This power should be reserved to template owners, who wrote the template, and know how the
steps state can be changed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes: resolver users used to have the right to change the step state: this is now reserved to admins and `allowed_resolver_usernames` of the `task_template`.

cc @simonmartinez in case RBAC need to be adapted on the UI

* **Other information**:
