### PR TITLE
feat: resolution: implemented task start-over

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,31 +10,34 @@ run:
 
 linters:
   enable:
-    - govet
-    - megacheck
-    - staticcheck
-    - deadcode
-    - structcheck
-    - typecheck
-    - gosimple
-    - varcheck
-    - ineffassign
-    - bodyclose
     - asciicheck
-    - exportloopref
-    - goconst
-    - misspell
-    - gofmt
-    - goimports
-    - predeclared
-    - gosec
-    - golint
-    - nolintlint
-    - unconvert
+    - bodyclose
+    - deadcode
     - errcheck
     - exportloopref
+    - goconst
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - megacheck
+    - misspell
+    - nolintlint
+    - prealloc
+    - predeclared
+    - revive
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
     - unparam
     - unused
+    - varcheck
+    - wastedassign
+    - whitespace
 
   disable:
     - maligned

--- a/db/migration.go
+++ b/db/migration.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 
+	"github.com/Masterminds/squirrel"
 	_ "github.com/lib/pq" // postgresql driver
 	"github.com/loopfz/gadgeto/zesty"
 
@@ -11,21 +13,33 @@ import (
 )
 
 const (
-	expectedVersion = "v1.10.0-migration005"
+	expectedVersion = "v1.17.0-migration006"
+)
+
+var (
+	baseQuery = sqlgenerator.PGsql.Select(
+		`"utask_sql_migrations".current_migration_applied`,
+	).From(
+		`"utask_sql_migrations"`,
+	)
 )
 
 // migrationChecker make sure that the latest SQL migration is correctly applied
 // otherwise, fails to start µTask.
+// SQL migrations are supposed to be added each time the database schema evolves. Previous migrations
+// are not supposed to be removed from the database, unless the SQL migration is a breaking change.
+// Keeping previous migration will avoid breaking the current running instance to break if the SQL migration
+// is applied, while µTask haven't been updated yet.
+// In case of a SQL breaking change, SQL migration should consider removing all previous SQL migration from the table
+// before adding the latest SQL migration version, to prevent old version to start with incompatible SQL schema.
 func migrationChecker() error {
 	dbp, err := zesty.NewDBProvider(utask.DBName)
 	if err != nil {
 		return err
 	}
 
-	sel := sqlgenerator.PGsql.Select(
-		`"utask_sql_migrations".current_migration_applied`,
-	).From(
-		`"utask_sql_migrations"`,
+	sel := baseQuery.Where(
+		squirrel.Eq{`"utask_sql_migrations".current_migration_applied`: expectedVersion},
 	).Limit(1)
 
 	query, params, err := sel.ToSql()
@@ -35,16 +49,43 @@ func migrationChecker() error {
 
 	row := dbp.DB().QueryRow(query, params...)
 	if err := row.Err(); err != nil {
-		return fmt.Errorf("unable to start µTask: missing latest SQL migration: %s", err)
+		return fmt.Errorf("unable to start µTask: can't fetch latest SQL migration: %s", err)
 	}
 
 	var version string
-	if err := row.Scan(&version); err != nil {
-		return fmt.Errorf("unable to start µTask: missing latest SQL migration: %s", err)
+	if err := row.Scan(&version); err != nil && err == sql.ErrNoRows {
+		lastVersionApplied, _ := lastKnownVersion(dbp)
+		if lastVersionApplied == "" {
+			return fmt.Errorf("unable to start µTask: migration table is empty, can't determine which SQL migration were already applied")
+		}
+
+		return fmt.Errorf("unable to start µTask: SQL database doesn't contains the latest SQL migration (%s). Last SQL migration applied according to the database: %s. Please apply all SQL migrations before starting the latest µTask version", expectedVersion, lastVersionApplied)
 	}
+
 	if version != expectedVersion {
 		return fmt.Errorf("unable to start µTask: missing latest SQL migration: expected %q, found %q", expectedVersion, version)
 	}
 
 	return nil
+}
+
+func lastKnownVersion(dbp zesty.DBProvider) (string, error) {
+	sel := baseQuery.OrderBy("current_migration_applied DESC").Limit(1)
+
+	query, params, err := sel.ToSql()
+	if err != nil {
+		return "", err
+	}
+
+	row := dbp.DB().QueryRow(query, params...)
+	if err := row.Err(); err != nil {
+		return "", fmt.Errorf("unable to start µTask: missing latest SQL migration: %s", err)
+	}
+
+	var version string
+	if err := row.Scan(&version); err != nil && err == sql.ErrNoRows {
+		return "", nil
+	}
+
+	return version, nil
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -52,9 +52,13 @@ func TestMain(m *testing.M) {
 	store := configstore.DefaultStore
 	store.InitFromEnvironment()
 
-	db.Init(store)
+	if err := db.Init(store); err != nil {
+		panic(err)
+	}
 
-	now.Init()
+	if err := now.Init(); err != nil {
+		panic(err)
+	}
 
 	var wg sync.WaitGroup
 

--- a/models/tasktemplate/fromdir_test.go
+++ b/models/tasktemplate/fromdir_test.go
@@ -34,9 +34,13 @@ func TestMain(m *testing.M) {
 	step.RegisterRunner(script.Plugin.PluginName(), script.Plugin)
 	step.RegisterRunner(pluginsubtask.Plugin.PluginName(), pluginsubtask.Plugin)
 
-	db.Init(store)
+	if err := db.Init(store); err != nil {
+		panic(err)
+	}
 
-	now.Init()
+	if err := now.Init(); err != nil {
+		panic(err)
+	}
 
 	os.Exit(m.Run())
 }

--- a/models/tasktemplate/template.go
+++ b/models/tasktemplate/template.go
@@ -37,6 +37,7 @@ type TaskTemplate struct {
 	Blocked                   bool     `json:"blocked" db:"blocked"`
 	Hidden                    bool     `json:"hidden" db:"hidden"`
 	RetryMax                  *int     `json:"retry_max,omitempty" db:"retry_max"`
+	AllowTaskStartOver        bool     `json:"allow_task_start_over" db:"allow_task_start_over"`
 
 	Inputs             []input.Input              `json:"inputs,omitempty" db:"inputs"`
 	ResolverInputs     []input.Input              `json:"resolver_inputs,omitempty" db:"resolver_inputs"`
@@ -60,6 +61,7 @@ func Create(dbp zesty.DBProvider,
 	resultFormat map[string]interface{},
 	titleFormat string,
 	retryMax *int,
+	allowTaskStartOver bool,
 	baseConfig map[string]json.RawMessage) (tt *TaskTemplate, err error) {
 
 	defer errors.DeferredAnnotatef(&err, "Failed to insert task template")
@@ -82,6 +84,7 @@ func Create(dbp zesty.DBProvider,
 		ResultFormat:              resultFormat,
 		TitleFormat:               titleFormat,
 		RetryMax:                  retryMax,
+		AllowTaskStartOver:        allowTaskStartOver,
 		BaseConfigurations:        baseConfig,
 	}
 
@@ -189,6 +192,7 @@ func (tt *TaskTemplate) Update(dbp zesty.DBProvider,
 	resultFormat map[string]interface{},
 	titleFormat *string,
 	retryMax *int,
+	allowTaskStartOver *bool,
 	baseConfig map[string]json.RawMessage) (err error) {
 
 	defer errors.DeferredAnnotatef(&err, "Failed to update template")
@@ -219,6 +223,9 @@ func (tt *TaskTemplate) Update(dbp zesty.DBProvider,
 	}
 	if hidden != nil {
 		tt.Hidden = *hidden
+	}
+	if allowTaskStartOver != nil {
+		tt.AllowTaskStartOver = *allowTaskStartOver
 	}
 	if steps != nil {
 		tt.Steps = steps
@@ -443,7 +450,7 @@ func validateVariables(variables []values.Variable) error {
 
 var (
 	ttBasicSelector = sqlgenerator.PGsql.Select(
-		`"task_template".id, "task_template".name, "task_template".description, "task_template".long_description, "task_template".doc_link, "task_template".allowed_resolver_usernames, "task_template".allow_all_resolver_usernames, "task_template".auto_runnable, "task_template".blocked, "task_template".hidden, "task_template".retry_max, "task_template".inputs, "task_template".resolver_inputs, "task_template".base_configurations, "task_template".tags`,
+		`"task_template".id, "task_template".name, "task_template".description, "task_template".long_description, "task_template".doc_link, "task_template".allowed_resolver_usernames, "task_template".allow_all_resolver_usernames, "task_template".auto_runnable, "task_template".blocked, "task_template".hidden, "task_template".retry_max, "task_template".allow_task_start_over, "task_template".inputs, "task_template".resolver_inputs, "task_template".base_configurations, "task_template".tags`,
 	).From(
 		`"task_template"`,
 	).OrderBy(

--- a/sql/migrations/006_task_template_add_allow_start_over.sql
+++ b/sql/migrations/006_task_template_add_allow_start_over.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+
+ALTER TABLE "task_template" ADD COLUMN "allow_task_start_over" BOOL NOT NULL DEFAULT false;
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.17.0-migration006');
+
+-- +migrate Down
+
+ALTER TABLE "task_template" DROP COLUMN "allow_task_start_over";
+
+DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.17.0-migration006';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE "task_template" (
     result_format JSONB NOT NULL,
     title_format TEXT NOT NULL,
     retry_max INTEGER,
+    allow_task_start_over BOOL NOT NULL DEFAULT false,
     base_configurations JSONB NOT NULL,
     tags JSONB NOT NULL DEFAULT 'null'
 );
@@ -110,6 +111,6 @@ CREATE TABLE "utask_sql_migrations" (
     current_migration_applied TEXT PRIMARY KEY
 );
 
-INSERT INTO "utask_sql_migrations" VALUES ('v1.10.0-migration005');
+INSERT INTO "utask_sql_migrations" VALUES ('v1.17.0-migration006');
 
 END;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the new behavior (if this is a feature change)?**
Once a resolution is executed, we can now start-over a task to its
initial state if the resolution were stuck in BAD_REQUEST, CANCELLED or
PAUSED state. It grants admins a way to amend the execution of a
resolution. This feature can also be granted to resolvers of a
resolution, so they can start-over themselves, using the boolean
`allow_task_start_over` in the template.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Need an update of the UI provided by @simonmartinez 