### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -78,13 +78,13 @@ func TestMain(m *testing.M) {
 
 func loadTemplates() map[string][]byte {
 	templateList := map[string][]byte{}
-	files, err := ioutil.ReadDir(testDirTemplates)
+	files, err := os.ReadDir(testDirTemplates)
 	if err != nil {
 		panic(err)
 	}
 
 	for _, file := range files {
-		if file.Mode().IsRegular() {
+		if file.Type().IsRegular() {
 			bytes, err := ioutil.ReadFile(filepath.Join(testDirTemplates, file.Name()))
 			if err != nil {
 				panic(err)

--- a/engine/functions/functions.go
+++ b/engine/functions/functions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"regexp"
@@ -149,7 +150,7 @@ func (f *Function) MetadataSchema() json.RawMessage {
 
 // LoadFromDir loads recursively all the function from a given directory.
 func LoadFromDir(directory string) error {
-	files, err := ioutil.ReadDir(directory)
+	files, err := os.ReadDir(directory)
 	if err != nil {
 		logrus.Warnf("Ignoring functions directory %s: %s", directory, err)
 		return nil

--- a/models/tasktemplate/fromdir.go
+++ b/models/tasktemplate/fromdir.go
@@ -3,6 +3,7 @@ package tasktemplate
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -20,7 +21,7 @@ var (
 // LoadFromDir reads yaml-formatted task templates
 // from a folder and upserts them in database
 func LoadFromDir(dbp zesty.DBProvider, dir string) error {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("Failed to open template directory %s: %s", dir, err)
 	}

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -2,7 +2,7 @@ package plugins
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"plugin"
 	"reflect"
 	"strings"
@@ -75,7 +75,7 @@ func InitializersFromFolder(path string, service *Service) error {
 }
 
 func loadPlugins(path string, load func(string, plugin.Symbol) error) error {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		logrus.Warnf("Ignoring plugin directory %s: %s", path, err)
 	} else {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactoring


* **What is the current behavior?** (You can also link to an open issue here)
Using `ioutil.ReadDir` to read the directory with full stat information


* **What is the new behavior (if this is a feature change)?**
  Use `os.ReadDir` to read directories without additional stat information.
  
  `os.ReadDir` is a more efficient than `ioutil.ReadDir` as stated here https://pkg.go.dev/io/ioutil#ReadDir. Since we are only reading the directory for `Name()` and filemode bits (`IsDir()` and `IsRegular()`)

  The full proposal for `os.ReadDir` can be read here: https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
