### PR TITLE
chore: change goreleaser install method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ run-test-stack-docker:
 	bash hack/test-docker.sh bash hack/interactive.sh
 
 run-goreleaser:
-	export BINDIR=${GOPATH}/bin; curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+	export BINDIR=${GOPATH}/bin; go install github.com/goreleaser/goreleaser@v1.6.3
 ifneq (,$(findstring -dev,$(VERSION)))
 	@echo Run Goreleaser in snapshot mod
 	$(call goreleaser,--snapshot)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Bad install method for goreleaser


* **What is the new behavior (if this is a feature change)?**
Switching to `go install`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
