### PR TITLE
fix: mark resolution as waiting instead of deadlock

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -516,7 +516,7 @@ forLoop:
 	// compute resolution state
 	if !allDone {
 		// from candidate resolution states, choose a resolution state by priority
-		for _, status := range []string{resolution.StateCrashed, resolution.StateBlockedFatal, resolution.StateBlockedBadRequest, resolution.StateError, resolution.StateBlockedDeadlock, resolution.StateWaiting} {
+		for _, status := range []string{resolution.StateCrashed, resolution.StateBlockedFatal, resolution.StateBlockedBadRequest, resolution.StateError, resolution.StateWaiting, resolution.StateBlockedDeadlock} {
 			if mapStatus[status] {
 				res.SetState(status)
 				break


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Currently, when we have a step which is a **subtask** in `WAITING` state, the resolution is **_dead locked_**.

* **What is the new behavior (if this is a feature change)?**
With this new version, the resolution will be `WAITING` as expected.