### PR TITLE
fix(json-schema): allow pre_hook in step

### DIFF
--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -67,6 +67,9 @@
                         "type": "string"
                     }
                 },
+                "pre_hook": {
+                    "$ref": "#/definitions/Action"
+                },
                 "action": {
                     "$ref": "#/definitions/Action"
                 },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

json-schema update.

* **What is the current behavior?** (You can also link to an open issue here)

The json-schema doesn't allow to declare a `pre_hook` in a `Step`.

* **What is the new behavior (if this is a feature change)?**

The json-schema allows to declare a `pre_hook` in a `Step`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking change.

* **Other information**:
