### PR TITLE
feat: allow to hide some inputs of templates

### DIFF
--- a/engine/input/input.go
+++ b/engine/input/input.go
@@ -32,6 +32,7 @@ type Input struct {
 	Type        string        `json:"type,omitempty"`
 	Optional    bool          `json:"optional"`
 	Default     interface{}   `json:"default"`
+	Hidden      bool          `json:"hidden"`
 }
 
 // Valid asserts that an input definition is valid

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -877,6 +877,11 @@
                     "type": "boolean",
                     "description": "Indicates if multiple values can be specified for this input",
                     "default": false
+                },
+                "hidden": {
+                    "type": "boolean",
+                    "description": "Indicates if the input is hidden on the task spawn form",
+                    "default": false
                 }
             }
         },

--- a/ui/dashboard/projects/utask-lib/src/lib/@components/inputs-form/inputs-form.component.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@components/inputs-form/inputs-form.component.ts
@@ -4,7 +4,7 @@ import { ResolverInput } from '../../@models/task.model';
 @Component({
 	selector: 'lib-utask-inputs-form',
 	templateUrl: './inputs-form.html',
-	styleUrls: ['./inputs-form.sass'],
+	styleUrls: ['./inputs-form.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class InputsFormComponent {

--- a/ui/dashboard/projects/utask-lib/src/lib/@components/inputs-form/inputs-form.html
+++ b/ui/dashboard/projects/utask-lib/src/lib/@components/inputs-form/inputs-form.html
@@ -1,5 +1,5 @@
 <form *ngIf="formGroup && inputs" nz-form [formGroup]="formGroup" [nzLayout]="'vertical'">
-    <nz-form-item *ngFor="let input of inputs; trackBy: trackInput">
+    <nz-form-item *ngFor="let input of inputs; trackBy: trackInput" [ngClass]="{'hidden': input.hidden}">
         <nz-form-label *ngIf="input.regex" nzFor="input_{{input.name}}" [nzRequired]="!input.optional"
             [nzTooltipTitle]="input.regex" nzTooltipIcon="info-circle">
             {{input.description ? input.description : input.name}}

--- a/ui/dashboard/projects/utask-lib/src/lib/@components/inputs-form/inputs-form.scss
+++ b/ui/dashboard/projects/utask-lib/src/lib/@components/inputs-form/inputs-form.scss
@@ -1,0 +1,3 @@
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
No way to hide inputs


* **What is the new behavior (if this is a feature change)?**
We can add the `hidden` attribute with the `true` value to an input to hide it. We still can set the input value through the URL.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change.


* **Other information**:
The goal is to simplify forms when we need to declare some system inputs.