### PR TITLE
chore(dep): migrating µTask build to Go 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN BASEHREF=___UTASK_DASHBOARD_BASEHREF___ PREFIX_API_BASE_URL=___UTASK_DASHBOA
 WORKDIR /home/node/ui/editor
 RUN BASEHREF=___UTASK_EDITOR_BASEHREF___ SENTRY_DSN=___UTASK_DASHBOARD_SENTRY_DSN___ make build-prod
 
-FROM golang:1.17-buster
+FROM golang:1.18
 
 COPY .  /go/src/github.com/ovh/utask
 WORKDIR /go/src/github.com/ovh/utask

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ release-utask-lib:
 
 test:
 	# moving to another location to go get some packages, otherwise it will include those packages as dependencies in go.mod
-	cd ${HOME} && go get github.com/jstemmer/go-junit-report github.com/stretchr/testify/assert
-	GO111MODULE=on DEV=true bash hack/test.sh ${TEST_CMD} 2>&1 | go-junit-report > report.xml
+	cd ${HOME} && go install github.com/jstemmer/go-junit-report/v2@latest
+	GO111MODULE=on DEV=true bash hack/test.sh ${TEST_CMD} 2>&1 | go-junit-report -set-exit-code > report.xml
 
 test-travis:
 	# moving to another location to go get some packages, otherwise it will include those packages as dependencies in go.mod

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1095,6 +1095,11 @@ func TestScriptPluginEnvironmentVariables(t *testing.T) {
 	assert.NotNil(t, res)
 	assert.Nil(t, err)
 
+	assert.Equal(t, step.StateDone, res.State)
+	assert.Equal(t, step.StateDone, res.Steps["stepOne"].State)
+	t.Log(res.Steps["stepOne"].Error)
+	t.Log(res.Steps["stepOne"].Metadata)
+
 	assert.NotNil(t, res.Steps["stepOne"].Output)
 
 	environment := res.Steps["stepOne"].Output.(map[string]interface{})

--- a/engine/scripts_tests/env-vars.py
+++ b/engine/scripts_tests/env-vars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import os


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore


* **What is the current behavior?** (You can also link to an open issue here)
Build using Go 1.17


* **What is the new behavior (if this is a feature change)?**
Build using Go 1.18


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
