### PR TITLE
fix: execute external init plugins before builtins

### DIFF
--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -146,12 +146,12 @@ var rootCmd = &cobra.Command{
 		service := &plugins.Service{Store: store, Server: server}
 
 		for _, err := range []error{
+			// run custom initialization code built as *.so plugins
+			plugins.InitializersFromFolder(utask.FInitializersFolder, service),
 			// register builtin initializers
 			builtin.RegisterInit(service),
 			// register builtin executors
 			builtin.Register(),
-			// run custom initialization code built as *.so plugins
-			plugins.InitializersFromFolder(utask.FInitializersFolder, service),
 			// load custom executors built as *.so plugins
 			plugins.ExecutorsFromFolder(utask.FPluginFolder),
 			// load the functions


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix: execute external init plugins before builtin init plugins.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
