### PR TITLE
feat(notify): use logrus to capture errors

### DIFF
--- a/pkg/notify/errors.go
+++ b/pkg/notify/errors.go
@@ -1,12 +1,40 @@
 package notify
 
-import "fmt"
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/ovh/utask"
+)
 
 const (
 	errSendCommon string = "Error while sending notification on"
 )
 
-// WrappedSendError print a formatted string from Send Notify in case of issue
-func WrappedSendError(etype string, err string) {
-	fmt.Printf("%s %s: %s", errSendCommon, etype, err)
+// WrappedSendError captures an error from Send Notify
+func WrappedSendError(err error, m *Message, backend, name string) {
+	newLogger(err, m, backend, name).
+		Errorf("%s %s", errSendCommon, backend)
+}
+
+// WrappedSendErrorWithBody captures an error with a response body from Send Notify.
+func WrappedSendErrorWithBody(err error, m *Message, backend, name, body string) {
+	newLogger(err, m, backend, name).
+		WithField("response_body", body).
+		Errorf("%s %s", errSendCommon, backend)
+}
+
+// newLogger creates a logger instance with pre-filled fields.
+func newLogger(err error, m *Message, backend, name string) *log.Entry {
+	var taskID string
+	if m != nil { // avoid panic if `m` is nil
+		taskID = m.Fields["task_id"]
+	}
+
+	return log.WithFields(log.Fields{
+		"notify_backend":    backend,
+		"notifier_name":     name,
+		"task_id":           taskID,
+		"notification_type": m.NotificationType,
+		"instance_id":       utask.InstanceID,
+	}).WithError(err)
 }

--- a/pkg/notify/opsgenie/opsgenie.go
+++ b/pkg/notify/opsgenie/opsgenie.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+
 	"github.com/ovh/utask/pkg/notify"
 )
 
@@ -75,7 +76,7 @@ func (ns *NotificationSender) Send(m *notify.Message, name string) {
 
 	_, err := ns.client.Create(ctx, req)
 	if err != nil {
-		notify.WrappedSendError(Type, err.Error())
+		notify.WrappedSendError(err, m, Type, name)
 		return
 	}
 }

--- a/pkg/notify/tat/tat.go
+++ b/pkg/notify/tat/tat.go
@@ -50,7 +50,7 @@ func NewTatNotificationSender(url, user, pass, topic string) (*NotificationSende
 func (tn *NotificationSender) Send(m *notify.Message, name string) {
 	client, err := tn.spawnTatClient()
 	if err != nil {
-		fmt.Println(err)
+		notify.WrappedSendError(err, m, Type, name)
 		return
 	}
 
@@ -64,7 +64,7 @@ func (tn *NotificationSender) Send(m *notify.Message, name string) {
 		},
 	)
 	if err != nil {
-		fmt.Println(err)
+		notify.WrappedSendError(err, m, Type, name)
 		return
 	}
 	// TODO create message for task creation


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Improvement: use logrus to capture errors from Send Notify to standardize the errors logs.

* **What is the current behavior?** (You can also link to an open issue here)

The error logs aren't standardized. 

* **What is the new behavior (if this is a feature change)?**

All notify backend use the same function to capture an error and the error logs are standardized.
Also, some fields have been added to simplify the debug.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

The format of error logs has changed to be standardized with the rest of the application. In case where an alerting system that parses the logs is used, the users need to change their configuration/rules.

* **Other information**:


An example of `notify_config` to test the new behaviour:

```json
"notify_config":{
   "test":{
      "type":"webhook",
      "config":{
         "webhook_url":"http://localhost:7777"
      }
   }
}
```


```
# Before
2022/10/05 21:31:43 Post "http://localhost:7777": dial tcp [::1]:7777: connect: connection refused

# After
ERRO[2022-10-05T21:26:22+02:00] Error while sending notification on webhook   error="Post \"http://localhost:7777\": dial tcp [::1]:7777: connect: connection refused" instance_id=8 notification_type=task_state_update notifier_name=test notify_backend=webhook task_id=8f971130-cadf-498d-ac3c-50c799e97d50
```

