### PR TITLE
feat: add compress package & the ability to compress steps in a resolution

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ovh/utask/models/task"
 	"github.com/ovh/utask/models/tasktemplate"
 	"github.com/ovh/utask/pkg/auth"
+	compress "github.com/ovh/utask/pkg/compress/init"
 	"github.com/ovh/utask/pkg/now"
 	"github.com/ovh/utask/pkg/plugins/builtin/echo"
 	"github.com/ovh/utask/pkg/plugins/builtin/script"
@@ -68,6 +69,10 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := auth.Init(store); err != nil {
+		panic(err)
+	}
+
+	if err := compress.Register(); err != nil {
 		panic(err)
 	}
 

--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -26,6 +26,7 @@ import (
 	functionsrunner "github.com/ovh/utask/engine/functions/runner"
 	"github.com/ovh/utask/models/tasktemplate"
 	"github.com/ovh/utask/pkg/auth"
+	compress "github.com/ovh/utask/pkg/compress/init"
 	notify "github.com/ovh/utask/pkg/notify/init"
 	"github.com/ovh/utask/pkg/plugins"
 	"github.com/ovh/utask/pkg/plugins/builtin"
@@ -146,6 +147,8 @@ var rootCmd = &cobra.Command{
 		service := &plugins.Service{Store: store, Server: server}
 
 		for _, err := range []error{
+			// register compression algorithms
+			compress.Register(),
 			// run custom initialization code built as *.so plugins
 			plugins.InitializersFromFolder(utask.FInitializersFolder, service),
 			// register builtin initializers
@@ -177,6 +180,8 @@ var rootCmd = &cobra.Command{
 		server.SetEditorPathPrefix(cfg.EditorPathPrefix)
 		server.SetDashboardSentryDSN(cfg.DashboardSentryDSN)
 		server.SetMaxBodyBytes(cfg.ServerOptions.MaxBodyBytes)
+
+		utask.StepsCompressionAlg = cfg.StepsCompression
 
 		if utask.FDebug {
 			log.SetLevel(log.DebugLevel)

--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -181,7 +181,7 @@ var rootCmd = &cobra.Command{
 		server.SetDashboardSentryDSN(cfg.DashboardSentryDSN)
 		server.SetMaxBodyBytes(cfg.ServerOptions.MaxBodyBytes)
 
-		utask.StepsCompressionAlg = cfg.StepsCompression
+		utask.StepsCompressionAlg = cfg.StepsCompressionAlg
 
 		if utask.FDebug {
 			log.SetLevel(log.DebugLevel)

--- a/config/README.md
+++ b/config/README.md
@@ -167,7 +167,10 @@ postgres://user:pass@db/utask?sslmode=disable
     // dashboard_sentry_dsn defines the Sentry DSN for the Dashboard UI. Used to retrieve Javascript execution errors inside a Sentry instance.
     // default: empty, no SENTRY_DSN
     "dashboard_sentry_dsn": "",
-     // server_options holds configuration to fine-tune DB connection
+    // steps_compression_algorithm defines the compression algorithm to use to compress the steps data in database.
+    // default: empty, no compression. Available compression algorithms: gzip
+    "steps_compression_algorithm": "",
+    // server_options holds configuration to fine-tune DB connection
     "server_options": {
         // max_body_bytes defines the maximum size that will be read when sending a body to the uTask server.
         // value can't be smaller than 1KB (1024), and can't be bigger than 10MB (10*1024*1024)

--- a/db/migration.go
+++ b/db/migration.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	expectedVersion = "v1.20.0-migration008"
+	expectedVersion = "v1.21.0-migration009"
 )
 
 var (

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ovh/utask/models/resolution"
 	"github.com/ovh/utask/models/task"
 	"github.com/ovh/utask/models/tasktemplate"
+	compress "github.com/ovh/utask/pkg/compress/init"
 	"github.com/ovh/utask/pkg/now"
 	"github.com/ovh/utask/pkg/plugins"
 	plugincallback "github.com/ovh/utask/pkg/plugins/builtin/callback"
@@ -68,6 +69,10 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := now.Init(); err != nil {
+		panic(err)
+	}
+
+	if err := compress.Register(); err != nil {
 		panic(err)
 	}
 

--- a/pkg/compress/compress.go
+++ b/pkg/compress/compress.go
@@ -1,0 +1,42 @@
+package compress
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	compressions    = map[string]Compression{}
+	compressionsMut sync.Mutex
+)
+
+type Compression interface {
+	Compress([]byte) ([]byte, error)
+	Decompress([]byte) ([]byte, error)
+}
+
+// RegisterAlgorithm registers a custom compression algorithm.
+func RegisterAlgorithm(name string, c Compression) error {
+	if c == nil {
+		return nil
+	}
+	compressionsMut.Lock()
+	defer compressionsMut.Unlock()
+	_, found := compressions[name]
+	if found {
+		return fmt.Errorf("conflicting compression key compressions: %s", name)
+	}
+	compressions[name] = c
+	return nil
+}
+
+func Get(name string) (Compression, error) {
+	compressionsMut.Lock()
+	defer compressionsMut.Unlock()
+
+	c, ok := compressions[name]
+	if !ok {
+		return nil, fmt.Errorf("%s compression algorithm not found", name)
+	}
+	return c, nil
+}

--- a/pkg/compress/gzip/gzip.go
+++ b/pkg/compress/gzip/gzip.go
@@ -1,0 +1,44 @@
+package gzip
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+
+	"github.com/ovh/utask/pkg/compress"
+)
+
+const AlgorithmName = "gzip"
+
+type gzipCompression struct{}
+
+// New returns a new compress.Compression with gzip as the compression algorithm.
+func New() compress.Compression {
+	return &gzipCompression{}
+}
+
+// Compress transforms data into a compressed form.
+func (c *gzipCompression) Compress(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+
+	if _, err := zw.Write(data); err != nil {
+		_ = zw.Close()
+		return nil, err
+	}
+
+	// Need to close the gzip writer before accessing the underlying bytes
+	_ = zw.Close()
+	return buf.Bytes(), nil
+}
+
+// Decompress transforms compressed form into an uncompressed form.
+func (c *gzipCompression) Decompress(data []byte) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = zr.Close() }()
+
+	return io.ReadAll(zr)
+}

--- a/pkg/compress/gzip/gzip_test.go
+++ b/pkg/compress/gzip/gzip_test.go
@@ -1,0 +1,12 @@
+package gzip_test
+
+import (
+	"testing"
+
+	"github.com/ovh/utask/pkg/compress/gzip"
+	"github.com/ovh/utask/pkg/compress/tests"
+)
+
+func TestCompression(t *testing.T) {
+	tests.CompressionTests(t, gzip.New())
+}

--- a/pkg/compress/init/init.go
+++ b/pkg/compress/init/init.go
@@ -1,0 +1,24 @@
+package init
+
+import (
+	"github.com/ovh/utask/pkg/compress"
+	"github.com/ovh/utask/pkg/compress/gzip"
+	"github.com/ovh/utask/pkg/compress/noop"
+)
+
+// Register registers default compression algorithms.
+func Register() error {
+	noopCompress := noop.New()
+
+	for name, c := range map[string]compress.Compression{
+		"":                 noopCompress, // to ensure backwards compatibility
+		noop.AlgorithmName: noopCompress,
+		gzip.AlgorithmName: gzip.New(),
+	} {
+		if err := compress.RegisterAlgorithm(name, c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/compress/noop/noop.go
+++ b/pkg/compress/noop/noop.go
@@ -1,0 +1,20 @@
+package noop
+
+import "github.com/ovh/utask/pkg/compress"
+
+const AlgorithmName = "noop"
+
+type noneCompression struct{}
+
+// New returns a new compress.Compression with no compression algorithm.
+func New() compress.Compression {
+	return &noneCompression{}
+}
+
+func (c *noneCompression) Compress(data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func (c *noneCompression) Decompress(data []byte) ([]byte, error) {
+	return data, nil
+}

--- a/pkg/compress/noop/noop_test.go
+++ b/pkg/compress/noop/noop_test.go
@@ -1,0 +1,12 @@
+package noop_test
+
+import (
+	"testing"
+
+	"github.com/ovh/utask/pkg/compress/noop"
+	"github.com/ovh/utask/pkg/compress/tests"
+)
+
+func TestCompression(t *testing.T) {
+	tests.CompressionTests(t, noop.New())
+}

--- a/pkg/compress/tests/tests.go
+++ b/pkg/compress/tests/tests.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/utask/pkg/compress"
+)
+
+// CompressionTests executes a range of tests to test a `Compression` module.
+func CompressionTests(t *testing.T, c compress.Compression) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "Hello world", want: "Hello world!"},
+		{name: "Empty string", want: " "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.Compress([]byte(tt.want))
+			require.Nilf(t, err, "Compress(): %s", err)
+
+			got, err = c.Decompress(got)
+
+			require.Nilf(t, err, "Decompress(): %s", err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}

--- a/pkg/plugins/builtin/callback/handler_test.go
+++ b/pkg/plugins/builtin/callback/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/loopfz/gadgeto/zesty"
 	"github.com/ovh/configstore"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ovh/utask"
 	"github.com/ovh/utask/api"
 	"github.com/ovh/utask/db"
@@ -21,9 +23,9 @@ import (
 	"github.com/ovh/utask/models/resolution"
 	"github.com/ovh/utask/models/task"
 	"github.com/ovh/utask/models/tasktemplate"
+	compress "github.com/ovh/utask/pkg/compress/init"
 	"github.com/ovh/utask/pkg/now"
 	"github.com/ovh/utask/pkg/plugins"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -42,6 +44,10 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := now.Init(); err != nil {
+		panic(err)
+	}
+
+	if err := compress.Register(); err != nil {
 		panic(err)
 	}
 

--- a/sql/migrations/009_resolution_compression_step.sql
+++ b/sql/migrations/009_resolution_compression_step.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+
+ALTER TABLE "resolution" ADD COLUMN "steps_compression_alg" TEXT;
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.21.0-migration009');
+
+-- +migrate Down
+
+ALTER TABLE "resolution" DROP COLUMN "steps_compression_alg";
+
+DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.21.0-migration009';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -134,6 +134,6 @@ CREATE TABLE "utask_sql_migrations" (
     current_migration_applied TEXT PRIMARY KEY
 );
 
-INSERT INTO "utask_sql_migrations" VALUES ('v1.20.0-migration008');
+INSERT INTO "utask_sql_migrations" VALUES ('v1.21.0-migration009');
 
 END;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -100,6 +100,7 @@ CREATE TABLE "resolution" (
     crypt_key BYTEA NOT NULL,
     encrypted_resolver_input BYTEA,
     encrypted_steps BYTEA NOT NULL,
+    steps_compression_alg TEXT,
     base_configurations JSONB NOT NULL
 );
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The steps aren't compressed.

* **What is the new behavior (if this is a feature change)?**

Now, we can compress the steps in a resolution to reduce the row size in database.
The compression algorithm used is saved in database to ensure backward compatibility in the case where the compression algorithm is changed. 

By default, no compression algorithm is used.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


* **Other information**:

To compress in `gzip`, update `utask-cfg` to add: 

```json
{
    "steps_compression": "gzip"
}
```
