### PR TITLE
Some fixes for make test-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ test-dev:
 
 test-travis:
 	# moving to another location to go get some packages, otherwise it will include those packages as dependencies in go.mod
-	cd ${HOME} && go get golang.org/x/tools/cmd/cover github.com/mattn/goveralls
+	cd ${HOME} && go go install github.com/mattn/goveralls@latest
 	hack/test.sh ${TEST_CMD_COV}
 
 test-docker:
-	cd ${HOME} && go get golang.org/x/tools/cmd/cover github.com/mattn/goveralls
+	cd ${HOME} && go install github.com/mattn/goveralls@latest
 	DEV=true bash hack/test-docker.sh ${TEST_CMD}
 
 run-test-stack:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ MAIN_LOCATION	= ./cmd
 
 TEST_LOCATION	= ./...
 # timeout for go test is here to prevent tests running infinitely if one runResolution leads to a step that never recovers (e.g. missing push on a stepChan)
-# 15 seconds per unit tests should be enough
-TEST_CMD		= go test -count=1 -timeout 15s -v -cover -p 1 ${TEST_LOCATION}
+# 30 seconds per unit tests should be enough
+TEST_CMD		= go test -count=1 -timeout 30s -v -cover -p 1 ${TEST_LOCATION}
 TEST_CMD_COV	= ${TEST_CMD} -covermode=count -coverprofile=coverage.out
 
 SOURCE_FILES 	= $(shell find ./ -type f -name "*.go" | grep -v _test.go)

--- a/hack/test-docker.sh
+++ b/hack/test-docker.sh
@@ -5,7 +5,7 @@ export PG_PASSWORD="test"
 export PG_PORT="5432"
 export PG_DATABASENAME="test"
 
-PG_DOCKER_ID=$(docker run -v $PWD/sql/schema.sql:/docker-entrypoint-initdb.d/v0001.sql:ro -e POSTGRES_USER=$PG_USER -e POSTGRES_PASSWORD=$PG_PASSWORD -e POSTGRES_DBNAME=$PG_DATABASENAME -d postgres:9.6-alpine)
+PG_DOCKER_ID=$(docker run -v $PWD/sql/schema.sql:/docker-entrypoint-initdb.d/v0001.sql:ro -e POSTGRES_USER=$PG_USER -e POSTGRES_PASSWORD=$PG_PASSWORD -e POSTGRES_DBNAME=$PG_DATABASENAME -d postgres:14-alpine)
 
 echo "Spawned Postgres docker: $PG_DOCKER_ID"
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

`make test-docker` fails because the timeout has expired. 
use `go get` to install goveralls
use postgres:9.4 for tests 

* **What is the new behavior (if this is a feature change)?**

`make test-docker` is fixed (the timeout is increased)
use `go install` to install goveralls
use postgres:14 for tests 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Longest test:
```
ok      github.com/ovh/utask/engine     29.305s coverage: 78.1% of statements
```
