### PR TITLE
fix(sql): set empty string as default compression alg

### DIFF
--- a/sql/migrations/010_fix_resolution_compression_step.sql
+++ b/sql/migrations/010_fix_resolution_compression_step.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+
+UPDATE "resolution" SET "steps_compression_alg" = '' WHERE "steps_compression_alg" IS NULL;
+
+ALTER TABLE "resolution" ALTER COLUMN "steps_compression_alg" SET NOT NULL;
+ALTER TABLE "resolution" ALTER COLUMN "steps_compression_alg" SET DEFAULT '';
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.21.1-migration010');
+
+-- +migrate Down
+
+ALTER TABLE "resolution" ALTER COLUMN "steps_compression_alg" DROP NOT NULL;
+ALTER TABLE "resolution" ALTER COLUMN "steps_compression_alg" DROP DEFAULT;
+
+DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.21.1-migration010';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -100,7 +100,7 @@ CREATE TABLE "resolution" (
     crypt_key BYTEA NOT NULL,
     encrypted_resolver_input BYTEA,
     encrypted_steps BYTEA NOT NULL,
-    steps_compression_alg TEXT,
+    steps_compression_alg TEXT NOT NULL DEFAULT '',
     base_configurations JSONB NOT NULL
 );
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
resolutions created before the compression feature cannot be loaded because the `steps_compression_alg` column is filled with `NULL` as value.


* **What is the new behavior (if this is a feature change)?**
`NULL` value are replaced by empty strings, the column is not nullable anymore.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
-