### PR TITLE
fix: db migration version

### DIFF
--- a/db/migration.go
+++ b/db/migration.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	expectedVersion = "v1.21.0-migration009"
+	expectedVersion = "v1.21.1-migration010"
 )
 
 var (

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -134,6 +134,6 @@ CREATE TABLE "utask_sql_migrations" (
     current_migration_applied TEXT PRIMARY KEY
 );
 
-INSERT INTO "utask_sql_migrations" VALUES ('v1.21.0-migration009');
+INSERT INTO "utask_sql_migrations" VALUES ('v1.21.1-migration010');
 
 END;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
uTask isn't expected the correct database migration version


* **What is the new behavior (if this is a feature change)?**
uTask is now expecting the correct database migration version


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no breaking change


* **Other information**:
N/A