### PR TITLE
fix(resolution): restore hex.Decode/Encode when loading/storing ciphered data from database

### DIFF
--- a/models/resolution/resolution.go
+++ b/models/resolution/resolution.go
@@ -168,7 +168,7 @@ func Create(dbp zesty.DBProvider, t *task.Task, resolverInputs map[string]interf
 		return nil, err
 	}
 
-	dst := make([]byte, 0, hex.EncodedLen(len(encryptedSteps)))
+	dst := make([]byte, hex.EncodedLen(len(encryptedSteps)))
 	hex.Encode(dst, encryptedSteps)
 	r.EncryptedSteps = encryptedSteps
 
@@ -251,7 +251,7 @@ func load(dbp zesty.DBProvider, publicID string, locked bool, lockNoWait bool) (
 		return nil, err
 	}
 
-	dst := make([]byte, 0, hex.DecodedLen(len(r.EncryptedSteps)))
+	dst := make([]byte, hex.DecodedLen(len(r.EncryptedSteps)))
 
 	// if we can't hex Decode, we might be in the case of a Resolution row in database that was
 	// created between the v1.21.1 and v1.21.3 that was bugged, and failed to hex Encode/Decode the
@@ -259,7 +259,9 @@ func load(dbp zesty.DBProvider, publicID string, locked bool, lockNoWait bool) (
 	// often.
 	// See https://github.com/ovh/utask/commit/bf23fbb10b62bb487ac4ea01b1e519f85480e58b and migration
 	// from symmecrypt.Key.DecryptMarshal to symmecrypt.Key.Decrypt
-	_, _ = hex.Decode(dst, r.EncryptedSteps)
+	if _, err = hex.Decode(dst, r.EncryptedSteps); err != nil {
+		dst = r.EncryptedSteps
+	}
 
 	compressedSteps, err := models.EncryptionKey.Decrypt(dst, []byte(r.PublicID))
 	if err != nil {
@@ -391,7 +393,7 @@ func (r *Resolution) Update(dbp zesty.DBProvider) (err error) {
 		return err
 	}
 
-	dst := make([]byte, 0, hex.EncodedLen(len(compressedSteps)))
+	dst := make([]byte, hex.EncodedLen(len(compressedSteps)))
 	hex.Encode(dst, compressedSteps)
 	encryptedSteps, err := models.EncryptionKey.Encrypt(compressedSteps, []byte(r.PublicID))
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Romain Beuque <556072+rbeuque74@users.noreply.github.com>

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
` Failed to load resolution from public id: chacha20poly1305: message authentication failed`


* **What is the new behavior (if this is a feature change)?**
Previously, we were using symmecrypt.DecryptMarshal to load data from the database, and we switched to symmecrypt.Decrypt with bf23fbb10b62bb487ac4ea01b1e519f85480e58b.
This changed the behaviour because DecryptMarshal was also calling hex.Decode on the ciphered text before doing the Decrypt. We had to restore this behaviour to read old data from our database.
Same for EncryptMarshal/Encrypt/hex.Encode


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
