### PR TITLE
feat: allow to set a expression_timeout in variables

### DIFF
--- a/engine/values/values.go
+++ b/engine/values/values.go
@@ -44,10 +44,11 @@ type Values struct {
 // Variable holds a named variable, with either a JS expression to be evalued
 // or a concrete value
 type Variable struct {
-	Name             string      `json:"name"`
-	Expression       string      `json:"expression"`
-	Value            interface{} `json:"value"`
-	evalCachedResult interface{}
+	Name              string      `json:"name"`
+	Expression        string      `json:"expression"`
+	ExpressionTimeout string      `json:"expression_timeout"`
+	Value             interface{} `json:"value"`
+	evalCachedResult  interface{}
 }
 
 // NewValues instantiates a new Values holder,
@@ -430,7 +431,15 @@ func (v *Values) varEval(varName string) (interface{}, error) {
 		return nil, err
 	}
 
-	res, err := evalUnsafe(exp, time.Second*10)
+	var timeout = time.Second * 10
+	if i.ExpressionTimeout != "" {
+		timeout, err = time.ParseDuration(i.ExpressionTimeout)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	res, err := evalUnsafe(exp, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -976,6 +976,10 @@
                 "expression": {
                     "type": "string",
                     "description": "Javascript expression that will be evaluated (can be templated)"
+                },
+                "expression_timeout": {
+                    "type": "string",
+                    "description": "A valid golang duration which can be parsed by time.ParseDuration()"
                 }
             }
         },

--- a/models/tasktemplate/fromdir_test.go
+++ b/models/tasktemplate/fromdir_test.go
@@ -138,6 +138,22 @@ func TestInvalidVariablesTemplates(t *testing.T) {
 	tt.Normalize()
 	err = tt.Valid()
 	assert.Contains(t, fmt.Sprint(err), "expression and value can't be empty at the same time")
+
+	tt.Variables[0].Name = "toto"
+	tt.Variables[0].Expression = ""
+	tt.Variables[0].Value = "foo"
+	tt.Variables[0].ExpressionTimeout = "30s"
+	tt.Normalize()
+	err = tt.Valid()
+	assert.Contains(t, fmt.Sprint(err), "expression timeout cannot be defined when value is defined")
+
+	tt.Variables[0].Name = "toto"
+	tt.Variables[0].Expression = "1+1"
+	tt.Variables[0].Value = nil
+	tt.Variables[0].ExpressionTimeout = "foo"
+	tt.Normalize()
+	err = tt.Valid()
+	assert.Contains(t, fmt.Sprint(err), "invalid duration \"foo\"")
 }
 
 func TestDependenciesValidation(t *testing.T) {

--- a/models/tasktemplate/template.go
+++ b/models/tasktemplate/template.go
@@ -3,6 +3,7 @@ package tasktemplate
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/juju/errors"
@@ -450,6 +451,15 @@ func validateVariables(variables []values.Variable) error {
 		}
 		if variable.Value == nil && variable.Expression == "" {
 			return errors.BadRequestf("variable %q expression and value can't be empty at the same time", variable.Name)
+		}
+		if variable.Value != nil && variable.ExpressionTimeout != "" {
+			return errors.BadRequestf("variable %q expression timeout cannot be defined when value is defined", variable.Name)
+		}
+		if variable.ExpressionTimeout != "" {
+			_, err := time.ParseDuration(variable.ExpressionTimeout)
+			if err != nil {
+				return errors.BadRequestf("variable %q %s", variable.Name, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
hard coded javascript expression timeout


* **What is the new behavior (if this is a feature change)?**
authors of templates can customize the javascript expression timeout


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no breaking change


* **Other information**:
