### PR TITLE
chore(docker): add UI node_modules into the .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+ui/dashboard/node_modules


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
if you have a local *node_modules* directory, it's copied into the docker image


* **What is the new behavior (if this is a feature change)?**
local *node_modules* folder is ignored and not copied into the image


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no breaking change


* **Other information**:
