### PR TITLE
(feat): Add iterator to child metadata

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -791,6 +791,12 @@ func contractStep(s *step.Step, res *resolution.Resolution) {
 				if child.Metadata != nil {
 					childM[values.MetadataKey] = child.Metadata
 				}
+				childMMetadata := childM[values.MetadataKey].(map[string]interface{})
+				if childMMetadata == nil {
+					childMMetadata = make(map[string]interface{})
+				}
+				childMMetadata[values.IteratorKey] = child.Item
+				childM[values.MetadataKey] = childMMetadata
 				childM[values.StateKey] = child.State
 				var i interface{} = childM
 				collectedChildren = append(collectedChildren, i)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -672,6 +672,19 @@ func TestForeach(t *testing.T) {
 	firstItem := concatList[0].(map[string]interface{})
 	firstItemOutput := firstItem[values.OutputKey].(map[string]interface{})
 	assert.Equal(t, "foo-b-bar-b", firstItemOutput["concat"])
+
+	outputExpected := map[string]string{"foo": "foo-b", "bar": "bar-b"}
+	metadata, ok := firstItem[values.MetadataKey].(map[string]interface{})
+	require.True(t, ok)
+	iterator, ok := metadata[values.IteratorKey].(map[string]interface{})
+	require.True(t, ok)
+	outputInterface, ok := iterator["output"].(map[string]interface{})
+	require.True(t, ok)
+	output := make(map[string]string)
+	for key, value := range outputInterface {
+		output[key] = fmt.Sprintf("%v", value)
+	}
+	assert.Equal(t, outputExpected, output)
 }
 
 func TestForeachWithChainedIterations(t *testing.T) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
(feat) Add the iterator in the child metadata


* **What is the current behavior?** (You can also link to an open issue here)
The metadata currently does not contain the iterator


* **What is the new behavior (if this is a feature change)?**
A new parameter iterator is set in the metadata of a child containing the iterator itself


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
