### PR TITLE
fix(templating): allow task.request_groups in templating

### DIFF
--- a/models/tasktemplate/validate.go
+++ b/models/tasktemplate/validate.go
@@ -31,7 +31,7 @@ func validTemplate(template string, inputs, resolverInputs []string, steps map[s
 	}
 
 	stepNames := stepNames(steps)
-	taskInfoKeys := []string{"resolver_username", "created", "requester_username", "task_id", "region", "resolution_id"}
+	taskInfoKeys := []string{"resolver_username", "created", "requester_username", "requester_groups", "task_id", "region", "resolution_id"}
 	for _, m := range matches {
 		parts := strings.Split(m[1], ".")
 		if len(parts) >= 3 {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
We introduced `request_groups` into uTask, and in templating for `.task` side, but didn't allowed it to use.
https://github.com/ovh/utask/blob/93929c6d2fda5bee96cdb13daf1eb5fcd8a053d8/models/task/task.go#L670


* **What is the new behavior (if this is a feature change)?**
Allow it


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
