### PR TITLE
fix(schema): allow arrays in echo outputs

### DIFF
--- a/hack/template-schema.json
+++ b/hack/template-schema.json
@@ -323,6 +323,7 @@
                         },
                         "output": {
                             "type": [
+                                "array",
                                 "object",
                                 "string",
                                 "null"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
arrays aren't allowed (by the json-schema) in echo action outputs


* **What is the new behavior (if this is a feature change)?**
allow arrays are now allowed


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
