### PR TITLE
chore(editor): display deprecation message

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 ui/dashboard/node_modules
+vscode/node_modules

--- a/ui/editor/src/app/editor/editor.component.ts
+++ b/ui/editor/src/app/editor/editor.component.ts
@@ -23,6 +23,7 @@ const langTools = brace.acequire('ace/ext/language_tools');
 
 @Component({
   templateUrl: 'editor.html',
+  styleUrls: ['./editor.scss'],
 })
 export class EditorComponent implements OnInit {
   editor: Editor;

--- a/ui/editor/src/app/editor/editor.html
+++ b/ui/editor/src/app/editor/editor.html
@@ -22,6 +22,12 @@
     </ul>
   </nav>
 
+  <div class="deprecation m-0 p-0">
+    <div class="alert alert-warning" role="alert">
+      This web interface will be retired in an upcoming release, but don't worry, we've got you covered! We've developed a new VSCode extension to replace it. Download the extension now for a faster, more streamlined experience.
+    </div>
+  </div>
+
   <div class="row">
     <div class="col-6">
       <div id="ace-editor" fullHeight></div>

--- a/ui/editor/src/app/editor/editor.scss
+++ b/ui/editor/src/app/editor/editor.scss
@@ -1,0 +1,8 @@
+.deprecation {
+    display: flex;
+
+    .alert {
+        flex-grow: 1;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
ui deprecation


* **What is the current behavior?** (You can also link to an open issue here)
editor is not stay updated and will be replaced by the vscode extension


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no, the editor is deprecated


* **Other information**:
