### PR TITLE
fix(Docker/Makefile): keep utask version when using the Makefile inside the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ FROM golang:1.19
 
 COPY .  /go/src/github.com/ovh/utask
 WORKDIR /go/src/github.com/ovh/utask
-RUN make re && \
-    mv hack/Makefile-child Makefile && \
+RUN make re && make makefile && \
     mkdir -p /app/plugins /app/templates /app/config /app/init /app/static/dashboard && \
     mv hack/wait-for-it/wait-for-it.sh /wait-for-it.sh && \
-    chmod +x /wait-for-it.sh
+    chmod +x /wait-for-it.sh && \
+    go clean -cache && rm -rf /go/pkg/*
 WORKDIR /app
 
 COPY --from=js-builder /home/node/ui/dashboard/dist/utask-ui/  /app/static/dashboard/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifndef VERSION
 	VERSION = $(shell git describe --abbrev=3 --tags $(git rev-list --tags --max-count=1))-dev
 endif
 
-LAST_COMMIT		= `git rev-parse HEAD`
+LAST_COMMIT		:= $(shell git rev-parse HEAD)
 VERSION_PKG		= github.com/ovh/utask
 
 DOCKER			= 0
@@ -93,4 +93,7 @@ endif
 
 package:
 
-.PHONY: all clean test re package release test test-travis test-docker run-test-stack run-test-stack-docker run-goreleaser docker
+makefile:
+	sed -e 's/VERSION=/VERSION=${VERSION}/g' hack/Makefile-child | sed -e 's/LAST_COMMIT=/LAST_COMMIT=${LAST_COMMIT}/g' >| Makefile  
+
+.PHONY: all clean test re package release test test-travis test-docker run-test-stack run-test-stack-docker run-goreleaser docker makefile

--- a/hack/Makefile-child
+++ b/hack/Makefile-child
@@ -1,6 +1,9 @@
+LAST_COMMIT=
+VERSION=
+
 all:
 	GO111MODULE=on go get -d -v  ./...
-	GO111MODULE=on go build -o utask ./cmd/utask
+	GO111MODULE=on go build -ldflags "-X github.com/ovh/utask.Commit=${LAST_COMMIT} -X github.com/ovh/utask.Version=${VERSION}" -o utask ./cmd/utask
 	for p in $$(ls ./plugins); do if [ -d ./plugins/$$p ]; then GO111MODULE=on go build --buildmode=plugin -o ./plugins/$$p.so ./plugins/$$p/*.go; fi; done
 	for p in $$(ls ./init);    do if [ -d ./init/$$p ];    then GO111MODULE=on go build --buildmode=plugin -o ./init/$$p.so    ./init/$$p/*.go;    fi; done
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Reduce the Docker image size
* Keep the utask version while using the Makefile inside the Docker image


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
