### PR TITLE
feat: add capability to read from multiple templates dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The µTask binary accepts the following arguments as binary args or env var.
 All are optional and have a default value:
 - `init-path`: the directory from where initialization plugins (see "Developing plugins") are loaded in *.so form (default: `./init`)
 - `plugins-path`: the directory from where action plugins (see "Developing plugins") are loaded in *.so form (default: `./plugins`)
-- `templates-path`: the directory where yaml-formatted task templates are loaded from (default: `./templates`)
+- `templates-path`: the directories where yaml-formatted task templates are loaded from, can be a colon separated list (default: `./templates`)
 - `functions-path`: the directory where yaml-formatted functions templates are loaded from (default: `./functions`)
 - `region`: an arbitrary identifier, to aggregate a running group of µTask instances (commonly containers), and differentiate them from another group, in a separate region (default: `default`)
 - `http-port`: the port on which the HTTP API listents (default: `8081`)

--- a/cmd/utask/root.go
+++ b/cmd/utask/root.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -79,7 +80,7 @@ func init() {
 
 	flags.StringVar(&utask.FInitializersFolder, "init-path", defaultInitializersFolder, "Initializer folder absolute path")
 	flags.StringVar(&utask.FPluginFolder, "plugins-path", defaultPluginFolder, "Plugins folder absolute path")
-	flags.StringVar(&utask.FTemplatesFolder, "templates-path", defaultTemplatesFolder, "Templates folder absolute path")
+	flags.StringVar(&utask.FTemplatesFolders, "templates-path", defaultTemplatesFolder, "Templates folders absolute paths, colon separated")
 	flags.StringVar(&utask.FFunctionsFolder, "functions-path", defaultFunctionsFolder, "Functions folder absolute path")
 	flags.StringVar(&utask.FScriptsFolder, "scripts-path", defaultScriptsFolder, "Scripts folder absolute path")
 	flags.StringVar(&utask.FRegion, "region", defaultRegion, "Region in which instance is located")
@@ -110,7 +111,7 @@ var rootCmd = &cobra.Command{
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		utask.FInitializersFolder = viper.GetString(envInit)
 		utask.FPluginFolder = viper.GetString(envPlugins)
-		utask.FTemplatesFolder = viper.GetString(envTemplates)
+		utask.FTemplatesFolders = viper.GetString(envTemplates)
 		utask.FScriptsFolder = viper.GetString(envScripts)
 		utask.FRegion = viper.GetString(envRegion)
 		utask.FPort = viper.GetUint(envHTTPPort)
@@ -197,9 +198,11 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		if err := tasktemplate.LoadFromDir(dbp, utask.FTemplatesFolder); err != nil {
-			return err
+		ds := strings.Split(utask.FTemplatesFolders, ":")
+		for _, dir := range ds {
+			if err := tasktemplate.LoadFromDir(dbp, dir); err != nil {
+				return err
+			}
 		}
 		var wg sync.WaitGroup
 		ctx, cancel := context.WithCancel(context.Background())

--- a/models/tasktemplate/fromdir.go
+++ b/models/tasktemplate/fromdir.go
@@ -22,7 +22,7 @@ var (
 func LoadFromDir(dbp zesty.DBProvider, dir string) error {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
-		return fmt.Errorf("Failed to open template directory %s: %s", dir, err)
+		return fmt.Errorf("failed to open template directory %s: %s", dir, err)
 	}
 	for _, file := range files {
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".yaml") {

--- a/utask.go
+++ b/utask.go
@@ -33,9 +33,9 @@ var (
 	// FPluginFolder is the path to a folder containing
 	// .so plugins to be registered as step action executors
 	FPluginFolder string
-	// FTemplatesFolder is the path to a folder containing
+	// FTemplatesFolders is a list of paths, colon separated, to folders containing
 	// .yaml templates for tasks
-	FTemplatesFolder string
+	FTemplatesFolders string
 	// FFunctionsFolder is the path to a folder containing
 	// functions files used by script plugin
 	FFunctionsFolder string


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Currently only one template directory can be set


* **What is the new behavior (if this is a feature change)?**
Now the input template directory can be a coma separated string list of filepath


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
