### PR TITLE
remove gin request log

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -172,7 +172,8 @@ func generatePathPrefixAPI(pathPrefix string) string {
 // build registers all routes and their corresponding handlers for the Server's API
 func (s *Server) build(ctx context.Context) {
 	if s.httpHandler == nil {
-		ginEngine := gin.Default()
+		ginEngine := gin.New()
+		ginEngine.Use(gin.Recovery())
 
 		ginEngine.
 			Group("/",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove gin request log


* **What is the current behavior?** (You can also link to an open issue here)
Currently, gin engine create logs for each request in the form `[GIN] 2024/04/04 - 15:00:11 | 200 |    1.431553ms | 198.244.140.254 | GET      "/unsecured/mon/ping"` whereas µtask implements its one access request logger middleware


* **What is the new behavior (if this is a feature change)?**
No more Gin engine request log


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
https://github.com/gin-gonic/gin/issues/2115