### PR TITLE
fix: ui: allow to edit task request when a resolution is PAUSED

### DIFF
--- a/ui/dashboard/projects/utask-lib/src/lib/@routes/task/task.component.ts
+++ b/ui/dashboard/projects/utask-lib/src/lib/@routes/task/task.component.ts
@@ -133,8 +133,12 @@ export class TaskComponent implements OnInit, OnDestroy {
     return !!meta?.user_is_admin;
   }));
 
-  readonly canEditRequest$ = combineLatest([this.task$, this._isResolver$]).pipe(map(([task, isResolver]) => {
-    if (!['TODO', 'PAUSED'].includes(task?.state)) {
+  readonly canEditRequest$ = combineLatest([this.task$, this._isResolver$, this.resolution$]).pipe(map(([task, isResolver, resolution]) => {
+    if (['TODO', 'DELAYED'].includes(task?.state)) {
+      return isResolver;
+    }
+
+    if (resolution?.state !== 'PAUSED') {
       return false;
     }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix

## Disclaimer

I'm not a UI developer, and haven't been able to test this in an environment