### PR TITLE
Add email attachment support to the Email action

### DIFF
--- a/pkg/plugins/builtin/email/README.md
+++ b/pkg/plugins/builtin/email/README.md
@@ -16,6 +16,7 @@ This plugin send an email.
 | `to`                  | receiver(s) of your email                     |
 | `subject`             | subject of your email                         |
 | `body`                | content of your email                         |
+| `attachments`         | file names of files to attach to the message  |
 
 ## Example
 
@@ -46,6 +47,8 @@ action:
     # mandatory, string
     body: |
       I love baguette
+    attachments:
+      - /tmp/generated-report.xlsx
 ```
 
 ## Note
@@ -54,11 +57,12 @@ The plugin returns an object to reuse the parameters in a future component:
 
 ```json
 {
-  "from_address":"foo@example.org",
-  "from_name":"uTask bot",
+  "from_address": "foo@example.org",
+  "from_name": "uTask bot",
   "to": ["bar@example.org", "hey@example.org"],
-  "subject":"Hello from µTask",
-  "body":"I love baguette"
+  "subject": "Hello from µTask",
+  "body": "I love baguette",
+  "attachments": ["/tmp/generated-report.xlsx"]
 }
 ```
 

--- a/pkg/plugins/builtin/email/email_test.go
+++ b/pkg/plugins/builtin/email/email_test.go
@@ -1,0 +1,71 @@
+package email
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	mail "gopkg.in/mail.v2"
+)
+
+func TestBuildMessage_NoAttachments(t *testing.T) {
+	config := &Config{
+		mailParameters: mailParameters{
+			FromAddress: "foo@example.com",
+			FromName:    "uTask Test",
+			To:          []string{"\"Test To 1\" <to1@example.com>", "\"Test To 2\" <to2@example.com>"},
+			Subject:     "Test Subject",
+			Body:        "Hello, world",
+		},
+	}
+
+	message := buildMessage(config)
+	lines := messageLines(message)
+
+	assert.Contains(t, lines, "From: \"uTask Test\" <foo@example.com>")
+	assert.Contains(t, lines, "To: \"Test To 1\" <to1@example.com>, \"Test To 2\" <to2@example.com>")
+	assert.Contains(t, lines, "Subject: Test Subject")
+	assert.Contains(t, lines, "Hello, world")
+}
+
+func TestBuildMessage_WithAttachment(t *testing.T) {
+	config := &Config{
+		mailParameters: mailParameters{
+			FromAddress: "foo@example.com",
+			FromName:    "uTask Test",
+			To:          []string{"\"Test To 1\" <to1@example.com>"},
+			Subject:     "Test Subject",
+			Body:        "Hello, world",
+			Attachments: []string{
+				"../../../../testdata/email-attachment.txt",
+			},
+		},
+	}
+
+	message := buildMessage(config)
+	lines := messageLines(message)
+
+	assert.Contains(t, lines, "From: \"uTask Test\" <foo@example.com>")
+	assert.Contains(t, lines, "To: \"Test To 1\" <to1@example.com>")
+	assert.Contains(t, lines, "Subject: Test Subject")
+	assert.Contains(t, lines, "Hello, world")
+	// Emails with attachments will be multipart/mixed
+	assert.Contains(t, lines, "Content-Type: multipart/mixed;")
+	// Did we get the attachment header and body?
+	assert.Contains(t, lines, "Content-Type: text/plain; charset=utf-8; name=\"email-attachment.txt\"")
+	assert.Contains(t, lines, "U2FtcGxlIGVtYWlsIGF0dGFjaG1lbnQg8J+OiQo=")
+}
+
+func messageLines(message *mail.Message) []string {
+	var buffer bytes.Buffer
+	message.WriteTo(&buffer)
+	scanner := bufio.NewScanner(&buffer)
+	lines := make([]string, 0)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	return lines
+}

--- a/testdata/email-attachment.txt
+++ b/testdata/email-attachment.txt
@@ -1,0 +1,1 @@
+Sample email attachment 🎉


### PR DESCRIPTION
Adds the ability to attach files to emails. This is useful if a previous step generates a report that you then want to email out.

I extracted out the building of `*mail.Message` to make the code more testable without needing a fake SMTP server. I opted to test for various headers that we would expect given our input.

Documentation updated to cover the new parameter.

* **What kind of change does this PR introduce?** feature, docs update
* **What is the current behavior?** No current support for file attachments
* **What is the new behavior (if this is a feature change)?** Attachments can now be added to emails sent by the email action
* **Does this PR introduce a breaking change?** No. Tests were written on the previous message building logic before making any changes.
