### PR TITLE
feat(cache): add the 'cache' plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ Browse [builtin actions](./pkg/plugins/builtin)
 | **`script`**   | Execute a script under `scripts` folder                                                                                                                                                                                                           | [Access plugin doc](./pkg/plugins/builtin/script/README.md)   |
 | **`tag`**      | Add tags to the current running task                                                                                                                                                                                                              | [Access plugin doc](./pkg/plugins/builtin/tag/README.md)      |
 | **`callback`** | Use callbacks to manage your tasks  life-cycle                                                                                                                                                                                                    | [Access plugin doc](./pkg/plugins/builtin/callback/README.md) |
+| **`cache`**    | Store and retrieve values in a key-value cache with optional TTL support                                                                                                                                                                          | [Access plugin doc](./pkg/plugins/builtin/cache/README.md)    |
 
 #### Pre-hooks <a name="pre-hooks"></a>
 

--- a/db/migration.go
+++ b/db/migration.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	expectedVersion = "v1.21.1-migration010"
+	expectedVersion = "v1.21.1-migration011"
 )
 
 var (

--- a/pkg/plugins/builtin/builtin.go
+++ b/pkg/plugins/builtin/builtin.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ovh/utask/pkg/plugins"
 	pluginapiovh "github.com/ovh/utask/pkg/plugins/builtin/apiovh"
 	pluginbatch "github.com/ovh/utask/pkg/plugins/builtin/batch"
+	plugincache "github.com/ovh/utask/pkg/plugins/builtin/cache"
 	plugincallback "github.com/ovh/utask/pkg/plugins/builtin/callback"
 	pluginecho "github.com/ovh/utask/pkg/plugins/builtin/echo"
 	pluginemail "github.com/ovh/utask/pkg/plugins/builtin/email"
@@ -22,6 +23,7 @@ import (
 func RegisterInit(service *plugins.Service) error {
 	for pluginName, pluginSymbol := range map[string]plugins.InitializerPlugin{
 		"callback": plugincallback.Init,
+		"cache":    plugincache.Init,
 	} {
 		if err := plugins.RegisterInit(pluginName, pluginSymbol, service); err != nil {
 			return err
@@ -45,6 +47,7 @@ func Register() error {
 		plugintag.Plugin,
 		plugincallback.Plugin,
 		pluginbatch.Plugin,
+		plugincache.Plugin,
 	} {
 		if err := step.RegisterRunner(p.PluginName(), p); err != nil {
 			return err

--- a/pkg/plugins/builtin/cache/README.md
+++ b/pkg/plugins/builtin/cache/README.md
@@ -1,0 +1,83 @@
+# `cache` Plugin
+
+This plugin provides a key-value cache backed by the database. Values can be stored with an optional TTL (time-to-live) in seconds. When a TTL is set, the entry is automatically cleaned up on read (lazy expiration) and at service startup (bulk purge). Setting a TTL of `0` (or omitting it) means the entry never expires.
+
+## Configuration
+
+| Field    | Description                                                                                                  |
+| -------- | ------------------------------------------------------------------------------------------------------------ |
+| `action` | `set` to store a value, `get` to retrieve a value, or `delete` to remove a value                             |
+| `key`    | the cache key (required for all actions)                                                                      |
+| `value`  | the value to store (only used with `set`; can be any JSON-compatible type: string, number, object, array...) |
+| `ttl`    | time-to-live in seconds (only used with `set`; `0` or omitted means no expiration)                            |
+
+## Example
+
+Store a value with a 1-hour TTL:
+
+```yaml
+cache-set:
+  action:
+    type: cache
+    configuration:
+      action: set
+      key: "my-key"
+      value:
+        foo: bar
+        count: 42
+      ttl: 3600
+```
+
+Retrieve the value:
+
+```yaml
+cache-get:
+  dependencies:
+    - cache-set
+  action:
+    type: cache
+    configuration:
+      action: get
+      key: "my-key"
+```
+
+Delete the value:
+
+```yaml
+cache-delete:
+  dependencies:
+    - cache-get
+  action:
+    type: cache
+    configuration:
+      action: delete
+      key: "my-key"
+```
+
+## Requirements
+
+None.
+
+## Return
+
+### `set` action output
+
+| Name     | Description                      |
+| -------- | -------------------------------- |
+| `key`    | the cache key that was set       |
+| `cached` | `true` if the value was stored   |
+
+### `get` action output
+
+| Name    | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
+| `key`   | the cache key that was looked up                                   |
+| `hit`   | `true` if the key was found and not expired, `false` otherwise     |
+| `value` | the cached value (or `null` if `hit` is `false`)                   |
+
+### `delete` action output
+
+| Name      | Description                      |
+| --------- | -------------------------------- |
+| `key`     | the cache key that was deleted   |
+| `deleted` | `true` if the delete was issued  |

--- a/pkg/plugins/builtin/cache/cache.go
+++ b/pkg/plugins/builtin/cache/cache.go
@@ -1,0 +1,121 @@
+package plugincache
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/loopfz/gadgeto/zesty"
+
+	"github.com/ovh/utask"
+	"github.com/ovh/utask/pkg/plugins/taskplugin"
+)
+
+var (
+	Plugin = taskplugin.New("cache", "0.1", exec,
+		taskplugin.WithConfig(validConfig, Config{}),
+	)
+)
+
+// Config holds the configuration for a cache action.
+// Action: "set", "get", or "delete"
+// Key: the cache key (required)
+// Value: the value to store (required for "set", ignored otherwise)
+// TTL: time-to-live in seconds (0 means no expiration, only used with "set")
+type Config struct {
+	Action string      `json:"action"`
+	Key    string      `json:"key"`
+	Value  interface{} `json:"value,omitempty"`
+	TTL    int64       `json:"ttl,omitempty"`
+}
+
+func validConfig(config interface{}) error {
+	cfg := config.(*Config)
+
+	if cfg.Key == "" {
+		return fmt.Errorf("missing required parameter %q", "key")
+	}
+
+	switch cfg.Action {
+	case "set":
+		return nil
+	case "get":
+		return nil
+	case "delete":
+		return nil
+	default:
+		return fmt.Errorf("invalid action %q: expected \"set\", \"get\", or \"delete\"", cfg.Action)
+	}
+}
+
+func exec(stepName string, config interface{}, ctx interface{}) (interface{}, interface{}, error) {
+	cfg := config.(*Config)
+
+	dbp, err := zesty.NewDBProvider(utask.DBName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch cfg.Action {
+	case "set":
+		return execSet(dbp, cfg)
+	case "get":
+		return execGet(dbp, cfg)
+	case "delete":
+		return execDelete(dbp, cfg)
+	default:
+		return nil, nil, errors.BadRequestf("invalid action %q", cfg.Action)
+	}
+}
+
+func execSet(dbp zesty.DBProvider, cfg *Config) (interface{}, interface{}, error) {
+	valueBytes, err := json.Marshal(cfg.Value)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal value: %s", err)
+	}
+
+	if err := setCacheEntry(dbp, cfg.Key, valueBytes, cfg.TTL); err != nil {
+		return nil, nil, err
+	}
+
+	return map[string]interface{}{
+		"key":    cfg.Key,
+		"cached": true,
+	}, nil, nil
+}
+
+func execGet(dbp zesty.DBProvider, cfg *Config) (interface{}, interface{}, error) {
+	entry, err := getCacheEntry(dbp, cfg.Key)
+	if err != nil {
+		if errors.Is(err, errors.NotFound) {
+			return map[string]interface{}{
+				"key":   cfg.Key,
+				"hit":   false,
+				"value": nil,
+			}, nil, nil
+		}
+		return nil, nil, err
+	}
+
+	var value interface{}
+	if err := json.Unmarshal(entry.Value, &value); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal cached value: %s", err)
+	}
+
+	return map[string]interface{}{
+		"key":   cfg.Key,
+		"hit":   true,
+		"value": value,
+	}, nil, nil
+}
+
+func execDelete(dbp zesty.DBProvider, cfg *Config) (interface{}, interface{}, error) {
+	if err := deleteCacheEntry(dbp, cfg.Key); err != nil {
+		return nil, nil, err
+	}
+
+	return map[string]interface{}{
+		"key":     cfg.Key,
+		"deleted": true,
+	}, nil, nil
+}

--- a/pkg/plugins/builtin/cache/init.go
+++ b/pkg/plugins/builtin/cache/init.go
@@ -1,0 +1,41 @@
+package plugincache
+
+import (
+	"github.com/loopfz/gadgeto/zesty"
+	"github.com/ovh/utask"
+	"github.com/ovh/utask/pkg/plugins"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	Init = &CacheInit{}
+)
+
+// CacheInit handles the plugin initialization: table registration
+// and periodic cleanup of expired entries.
+type CacheInit struct{}
+
+func (ci *CacheInit) Init(s *plugins.Service) error {
+	// No table model registration needed: we use raw SQL queries
+	// with squirrel, not gorp ORM mapping.
+
+	// Purge expired entries at startup
+	dbp, err := zesty.NewDBProvider(utask.DBName)
+	if err != nil {
+		logrus.Warnf("cache plugin: unable to get DB provider for initial purge: %s", err)
+		return nil
+	}
+
+	purged, err := purgeExpiredEntries(dbp)
+	if err != nil {
+		logrus.Warnf("cache plugin: initial purge failed: %s", err)
+	} else if purged > 0 {
+		logrus.Infof("cache plugin: purged %d expired entries at startup", purged)
+	}
+
+	return nil
+}
+
+func (ci *CacheInit) Description() string {
+	return "Cache plugin: key-value store with optional TTL expiration"
+}

--- a/pkg/plugins/builtin/cache/models.go
+++ b/pkg/plugins/builtin/cache/models.go
@@ -1,0 +1,113 @@
+package plugincache
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/juju/errors"
+	"github.com/loopfz/gadgeto/zesty"
+
+	"github.com/ovh/utask/db/pgjuju"
+	"github.com/ovh/utask/db/sqlgenerator"
+	"github.com/ovh/utask/pkg/now"
+)
+
+type cacheEntry struct {
+	Key       string     `db:"key"`
+	Value     []byte     `db:"value"`
+	ExpiresAt *time.Time `db:"expires_at"`
+}
+
+func (c *cacheEntry) isExpired() bool {
+	return c.ExpiresAt != nil && now.Get().After(*c.ExpiresAt)
+}
+
+func setCacheEntry(dbp zesty.DBProvider, key string, value []byte, ttl int64) error {
+	var expiresAt *time.Time
+	if ttl > 0 {
+		t := now.Get().Add(time.Duration(ttl) * time.Second)
+		expiresAt = &t
+	}
+
+	query, args, err := sqlgenerator.PGsql.
+		Insert(`"cache"`).
+		Columns(`"key"`, `"value"`, `"expires_at"`).
+		Values(key, value, expiresAt).
+		Suffix(`ON CONFLICT ("key") DO UPDATE SET "value" = EXCLUDED."value", "expires_at" = EXCLUDED."expires_at"`).
+		ToSql()
+	if err != nil {
+		return err
+	}
+
+	_, err = dbp.DB().Exec(query, args...)
+	if err != nil {
+		return pgjuju.Interpret(err)
+	}
+
+	return nil
+}
+
+func getCacheEntry(dbp zesty.DBProvider, key string) (*cacheEntry, error) {
+	query, args, err := sqlgenerator.PGsql.
+		Select(`"key"`, `"value"`, `"expires_at"`).
+		From(`"cache"`).
+		Where(squirrel.Eq{`"key"`: key}).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &cacheEntry{}
+	err = dbp.DB().SelectOne(entry, query, args...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, errors.NotFoundf("cache key %q", key)
+		}
+		return nil, pgjuju.Interpret(err)
+	}
+
+	if entry.isExpired() {
+		_ = deleteCacheEntry(dbp, key)
+		return nil, errors.NotFoundf("cache key %q", key)
+	}
+
+	return entry, nil
+}
+
+func deleteCacheEntry(dbp zesty.DBProvider, key string) error {
+	query, args, err := sqlgenerator.PGsql.
+		Delete(`"cache"`).
+		Where(squirrel.Eq{`"key"`: key}).
+		ToSql()
+	if err != nil {
+		return err
+	}
+
+	_, err = dbp.DB().Exec(query, args...)
+	if err != nil {
+		return pgjuju.Interpret(err)
+	}
+
+	return nil
+}
+
+func purgeExpiredEntries(dbp zesty.DBProvider) (int64, error) {
+	query, args, err := sqlgenerator.PGsql.
+		Delete(`"cache"`).
+		Where(squirrel.And{
+			squirrel.NotEq{`"expires_at"`: nil},
+			squirrel.Lt{`"expires_at"`: now.Get()},
+		}).
+		ToSql()
+	if err != nil {
+		return 0, err
+	}
+
+	res, err := dbp.DB().Exec(query, args...)
+	if err != nil {
+		return 0, pgjuju.Interpret(err)
+	}
+
+	return res.RowsAffected()
+}

--- a/sql/migrations/011_cache.sql
+++ b/sql/migrations/011_cache.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+
+CREATE TABLE "cache" (
+    "key" TEXT PRIMARY KEY,
+    "value" BYTEA NOT NULL,
+    "expires_at" TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX "cache_expires_at_idx" ON "cache" ("expires_at") WHERE "expires_at" IS NOT NULL;
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.21.1-migration011');
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS "cache_expires_at_idx";
+DROP TABLE IF EXISTS "cache";
+
+DELETE FROM "utask_sql_migrations" WHERE current_migration_applied = 'v1.21.1-migration011';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -134,6 +134,14 @@ CREATE TABLE "utask_sql_migrations" (
     current_migration_applied TEXT PRIMARY KEY
 );
 
-INSERT INTO "utask_sql_migrations" VALUES ('v1.21.1-migration010');
+CREATE TABLE "cache" (
+    "key" TEXT PRIMARY KEY,
+    "value" BYTEA NOT NULL,
+    "expires_at" TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX "cache_expires_at_idx" ON "cache" ("expires_at") WHERE "expires_at" IS NOT NULL;
+
+INSERT INTO "utask_sql_migrations" VALUES ('v1.21.1-migration011');
 
 END;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — new builtin plugin cache.

* **What is the current behavior?** (You can also link to an open issue here)

There is no built-in mechanism to store and retrieve arbitrary key-value data across steps or task executions.

* **What is the new behavior (if this is a feature change)?**

A new cache plugin is available with three actions:

 - set — stores a value (any JSON-compatible type) under a key, with an optional TTL in seconds (0 or omitted = no expiration).
 - get — retrieves a value by key. Returns hit: true/false. If the entry has expired, it is transparently deleted and treated as a cache miss.
 - delete — removes an entry by key.

Data is stored in a new cache PostgreSQL table (key TEXT, value BYTEA, expires_at TIMESTAMPTZ). Expired entries are also purged in bulk at service startup.

New SQL migration: 011_cache.sql (version v1.21.1-migration011).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. The new migration must be applied before deploying this version (as with any migration), but no existing behavior is affected.