### PR TITLE
fix: Fixed resolutions reaching BLOCKED_DEADLOCK when a Step's state is modified externally

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -359,6 +359,15 @@ func initialize(dbp zesty.DBProvider, publicID string, debugLogger *logrus.Entry
 		return nil, nil, nil
 	}
 
+	{
+		// Making sure to prune steps whose dependencies were updated outside the engine (API, manually in DB, etc)
+		stepsToCheck := map[string]bool{}
+		for stepName := range res.Steps {
+			stepsToCheck[stepName] = true
+		}
+		pruneSteps(res, stepsToCheck)
+	}
+
 	if err := dbp.Commit(); err != nil {
 		dbp.Rollback()
 		return nil, nil, err


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
Resolutions can end up in the `BLOCKED_DEADLOCK` state when one of their Steps is updated through the API because no pruning is performed.
Let's consider a simple task with 3 steps : `Parent`, `Child1` and `Child2`. `Child1` has the dependency `Parent:DONE`, `Child2` has `Parent:CUSTOM_STATE` (see attached picture). If `Parent` has an issue and can't reach either the `DONE` or `CUSTOM_STATE` and we were to update its state manually to the `DONE` state for example, `Child1` could be executed and `Child2` should reach the `PRUNE` state.  However, since no pruning is performed at this stage, `Child2` stays in `TODO` forever and the resolution becomes `BLOCKED_DEADLOCK`


* **What is the new behavior (if this is a feature change)?**
Proactive pruning is performed whenever a resolution is run.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that I am aware of.


* **Other information**:
<img width="542" height="223" alt="image" src="https://github.com/user-attachments/assets/89c6a004-0ad0-443d-b816-72c1f29aa6d4" />