### PR TITLE
feat(opsgenie): allow to override the opsgenie api url

### DIFF
--- a/pkg/notify/init/init.go
+++ b/pkg/notify/init/init.go
@@ -42,6 +42,7 @@ func Init(store *configstore.Store) error {
 			}
 			ogns, err := opsgenie.NewOpsGenieNotificationSender(
 				f.Zone,
+				f.APIURL,
 				f.APIKey,
 				f.Timeout,
 			)

--- a/pkg/notify/opsgenie/opsgenie.go
+++ b/pkg/notify/opsgenie/opsgenie.go
@@ -33,15 +33,21 @@ type NotificationSender struct {
 }
 
 // NewOpsGenieNotificationSender instantiates a NotificationSender
-func NewOpsGenieNotificationSender(zone, apikey, timeout string) (*NotificationSender, error) {
-	zonesToAPIUrls := map[string]client.ApiUrl{
-		ZoneDefault: client.API_URL,
-		ZoneEU:      client.API_URL_EU,
-		ZoneSandbox: client.API_URL_SANDBOX,
-	}
-	apiURL, present := zonesToAPIUrls[zone]
-	if !present {
-		return nil, errors.NotFoundf("opsgenie zone %q", zone)
+func NewOpsGenieNotificationSender(zone, apiurl, apikey, timeout string) (*NotificationSender, error) {
+	var apiURL client.ApiUrl
+	if apiurl != "" {
+		apiURL = client.ApiUrl(apiurl)
+	} else {
+		zonesToAPIUrls := map[string]client.ApiUrl{
+			ZoneDefault: client.API_URL,
+			ZoneEU:      client.API_URL_EU,
+			ZoneSandbox: client.API_URL_SANDBOX,
+		}
+		var present bool
+		apiURL, present = zonesToAPIUrls[zone]
+		if !present {
+			return nil, errors.NotFoundf("opsgenie zone %q", zone)
+		}
 	}
 	client, err := alert.NewClient(&client.Config{
 		ApiKey:         apikey,

--- a/utask.go
+++ b/utask.go
@@ -167,6 +167,7 @@ type TemplateNotificationStrategy struct {
 // NotifyBackendOpsGenie holds configuration for instantiating an OPsGenie notify client
 type NotifyBackendOpsGenie struct {
 	Zone    string `json:"zone"`
+	APIURL  string `json:"api_url"`
 	APIKey  string `json:"api_key"`
 	Timeout string `json:"timeout"`
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a new feature


* **What is the current behavior?** (You can also link to an open issue here)
The API URL used by opsgenie is retrieved from an hardcoded map of URL by zone which does not allow to use custom opsgenie endpoint


* **What is the new behavior (if this is a feature change)?**
It allows to provide the API URL to be used by opsgenie


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
