### PR TITLE
feat(opsgenie): support a base url with a path prefix

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -48,6 +48,10 @@ postgres://user:pass@db/utask?sslmode=disable
     // notify_config contains a map of named notification configurations, composed of a type and config data,
     // implemented notifiers include:
     // - opsgenie (https://www.atlassian.com/software/opsgenie); available zones are: global, eu, sandbox
+    //   the zone can be bypassed with api_url; prefer a full base URL including the scheme
+    //   (e.g. "https://api.atlassian.com/jsm/ops/integration" for Jira Service Management).
+    //   A bare host is still accepted for backward compatibility, but the scheme is then
+    //   inferred by the SDK and may fall back to plain HTTP
     // - slack webhook (https://api.slack.com/messaging/webhooks)
     // - generic webhook (custom URL, with HTTP POST method)
     // notification strategies can be declared per backend:

--- a/pkg/notify/opsgenie/opsgenie.go
+++ b/pkg/notify/opsgenie/opsgenie.go
@@ -3,6 +3,9 @@ package opsgenie
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -32,27 +35,39 @@ type NotificationSender struct {
 	client          *alert.Client
 }
 
-// NewOpsGenieNotificationSender instantiates a NotificationSender
+// NewOpsGenieNotificationSender instantiates a NotificationSender.
+// apiurl overrides the API URL derived from zone, it accepts either a bare host
+// (e.g. "api.eu.opsgenie.com") or a full base URL, scheme and path prefix included
+// (e.g. "https://api.atlassian.com/jsm/ops/integration").
 func NewOpsGenieNotificationSender(zone, apiurl, apikey, timeout string) (*NotificationSender, error) {
-	var apiURL client.ApiUrl
-	if apiurl != "" {
-		apiURL = client.ApiUrl(apiurl)
-	} else {
+	cfg := client.Config{ApiKey: apikey}
+
+	switch {
+	case apiurl == "":
 		zonesToAPIUrls := map[string]client.ApiUrl{
 			ZoneDefault: client.API_URL,
 			ZoneEU:      client.API_URL_EU,
 			ZoneSandbox: client.API_URL_SANDBOX,
 		}
-		var present bool
-		apiURL, present = zonesToAPIUrls[zone]
+		apiURL, present := zonesToAPIUrls[zone]
 		if !present {
 			return nil, errors.NotFoundf("opsgenie zone %q", zone)
 		}
+		cfg.OpsGenieAPIURL = apiURL
+	case strings.Contains(apiurl, "/"):
+		// the sdk only knows how to target a host, requests have to be rewritten
+		// to honor the scheme and the path prefix of the configured base URL
+		base, err := parseBaseURL(apiurl)
+		if err != nil {
+			return nil, err
+		}
+		cfg.OpsGenieAPIURL = client.ApiUrl(base.Host)
+		cfg.HttpClient = &http.Client{Transport: &baseURLTransport{base: base}}
+	default:
+		cfg.OpsGenieAPIURL = client.ApiUrl(apiurl)
 	}
-	client, err := alert.NewClient(&client.Config{
-		ApiKey:         apikey,
-		OpsGenieAPIURL: apiURL,
-	})
+
+	client, err := alert.NewClient(&cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +85,44 @@ func NewOpsGenieNotificationSender(zone, apiurl, apikey, timeout string) (*Notif
 		opsGenieTimeout: timeoutDuration,
 		client:          client,
 	}, nil
+}
+
+// parseBaseURL validates a configured OpsGenie base URL, defaulting its scheme to https.
+// The trailing slash is trimmed before parsing, to keep Path and RawPath consistent.
+func parseBaseURL(apiurl string) (*url.URL, error) {
+	if !strings.Contains(apiurl, "://") {
+		apiurl = "https://" + apiurl
+	}
+	base, err := url.Parse(strings.TrimSuffix(apiurl, "/"))
+	if err != nil {
+		return nil, errors.NewNotValid(err, "invalid opsgenie api url")
+	}
+	if base.Host == "" {
+		return nil, errors.NotValidf("opsgenie api url %q: missing host", apiurl)
+	}
+	if base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+		return nil, errors.NotValidf("opsgenie api url %q: only scheme, host and path are supported", apiurl)
+	}
+	return base, nil
+}
+
+// baseURLTransport reroutes the requests built by the OpsGenie sdk to a base URL,
+// prefixing their path so that endpoints such as
+// https://api.atlassian.com/jsm/ops/integration can be targeted
+type baseURLTransport struct {
+	base *url.URL
+}
+
+func (t *baseURLTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := req.Clone(req.Context())
+	r.URL.Scheme = t.base.Scheme
+	r.URL.Host = t.base.Host
+	r.URL.Path = t.base.Path + r.URL.Path
+	if r.URL.RawPath != "" {
+		r.URL.RawPath = t.base.EscapedPath() + r.URL.RawPath
+	}
+	r.Host = ""
+	return http.DefaultTransport.RoundTrip(r)
 }
 
 // Send dispatches a notify.Message to OpsGenie

--- a/pkg/notify/opsgenie/opsgenie_test.go
+++ b/pkg/notify/opsgenie/opsgenie_test.go
@@ -1,0 +1,147 @@
+package opsgenie
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recorder is an OpsGenie api stub, keeping every request it received
+type recorder struct {
+	*httptest.Server
+	mu       sync.Mutex
+	requests []*http.Request
+}
+
+func newRecorder() *recorder {
+	rec := &recorder{}
+	rec.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.mu.Lock()
+		rec.requests = append(rec.requests, r)
+		rec.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"result":"ok","took":0.1,"requestId":"foo"}`))
+	}))
+	return rec
+}
+
+// lastRequest returns the only request the stub received
+func (rec *recorder) lastRequest(t *testing.T) *http.Request {
+	t.Helper()
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	require.Len(t, rec.requests, 1)
+	return rec.requests[0]
+}
+
+// host returns the stub host, as accepted by the legacy bare host configuration
+func (rec *recorder) host() string {
+	return strings.TrimPrefix(rec.URL, "http://")
+}
+
+func TestNewOpsGenieNotificationSenderAPIURL(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		// apiurl is built from the stub URL, which is only known at runtime
+		apiurl       func(rec *recorder) string
+		expectedPath string
+	}{
+		{
+			name:         "base url with a path prefix",
+			apiurl:       func(rec *recorder) string { return rec.URL + "/jsm/ops/integration" },
+			expectedPath: "/jsm/ops/integration/v2/alerts",
+		},
+		{
+			name:         "base url with a trailing slash",
+			apiurl:       func(rec *recorder) string { return rec.URL + "/jsm/ops/" },
+			expectedPath: "/jsm/ops/v2/alerts",
+		},
+		{
+			name:         "base url without a path prefix",
+			apiurl:       func(rec *recorder) string { return rec.URL },
+			expectedPath: "/v2/alerts",
+		},
+		{
+			// legacy form, handled by the sdk itself
+			name:         "bare host",
+			apiurl:       func(rec *recorder) string { return rec.host() },
+			expectedPath: "/v2/alerts",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := newRecorder()
+			defer rec.Close()
+
+			ns, err := NewOpsGenieNotificationSender(ZoneDefault, tt.apiurl(rec), "secret", "5s")
+			require.NoError(t, err)
+
+			_, err = ns.client.Create(t.Context(), &alert.CreateAlertRequest{
+				Message: "hello",
+				Alias:   "dead-beef",
+			})
+			require.NoError(t, err)
+
+			req := rec.lastRequest(t)
+			assert.Equal(t, tt.expectedPath, req.URL.Path)
+			assert.Equal(t, rec.host(), req.Host)
+			assert.Equal(t, "GenieKey secret", req.Header.Get("Authorization"))
+		})
+	}
+}
+
+// TestNewOpsGenieNotificationSenderCloseAPIURL covers the request utask sends the most,
+// the only one with both a dynamic path segment and a query string
+func TestNewOpsGenieNotificationSenderCloseAPIURL(t *testing.T) {
+	rec := newRecorder()
+	defer rec.Close()
+
+	ns, err := NewOpsGenieNotificationSender(ZoneDefault, rec.URL+"/jsm/ops/integration", "secret", "5s")
+	require.NoError(t, err)
+
+	_, err = ns.client.Close(t.Context(), &alert.CloseAlertRequest{
+		IdentifierType:  alert.ALIAS,
+		IdentifierValue: "dead-beef",
+	})
+	require.NoError(t, err)
+
+	req := rec.lastRequest(t)
+	assert.Equal(t, "/jsm/ops/integration/v2/alerts/dead-beef/close", req.URL.Path)
+	assert.Equal(t, "alias", req.URL.Query().Get("identifierType"))
+}
+
+func TestNewOpsGenieNotificationSenderErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		zone, apiurl  string
+		expectedError string
+	}{
+		{
+			name:          "unknown zone",
+			zone:          "nowhere",
+			expectedError: `opsgenie zone "nowhere"`,
+		},
+		{
+			name:          "missing host",
+			zone:          ZoneDefault,
+			apiurl:        "https:///v2",
+			expectedError: "missing host",
+		},
+		{
+			name:          "unsupported url parts",
+			zone:          ZoneDefault,
+			apiurl:        "https://user:pass@api.atlassian.com/jsm/ops/integration?foo=bar",
+			expectedError: "only scheme, host and path are supported",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewOpsGenieNotificationSender(tt.zone, tt.apiurl, "secret", "")
+			assert.ErrorContains(t, err, tt.expectedError)
+		})
+	}
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
The api_url override was injected as-is into the sdk host, so any path got percent-escaped. 


* **What is the new behavior (if this is a feature change)?**
The api_url override is now parsed as a base URL and requests are rewritten to honor its scheme and path prefix


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
